### PR TITLE
nodejs: fix duplicate pin bug in v5 copy_board and get_board

### DIFF
--- a/nodejs/scripts/copy_board.js
+++ b/nodejs/scripts/copy_board.js
@@ -196,6 +196,10 @@ async function main (argv) {
     // copy board pins
     const pin_iterator = await source_board.get_pins();
     for await (let pin_data of pin_iterator) {
+      // ignore pins in sections for now. they will be copied into each section
+      if (pin_data.board_section_id) {
+        continue;
+      }
       if (args.dry_run) {
         console.log('dry-run: skipping attempt to create board pin:');
         Pin.print_summary(pin_data);

--- a/nodejs/scripts/get_board.js
+++ b/nodejs/scripts/get_board.js
@@ -42,6 +42,10 @@ async function main (argv) {
   if (args.pins) {
     const pin_iterator = await board.get_pins();
     for await (let pin_data of pin_iterator) {
+      // ignore pins in sections for now. they will be printed for each section
+      if (pin_data.board_section_id) {
+        continue;
+      }
       Pin.print_summary(pin_data);
     }
   }


### PR DESCRIPTION
v5 board.get_pins returns pins on sections in addition to pins on the main board. v3 board.get_pins only returns pins on the main board. The python code handled this case properly, but was not translated correctly to nodejs. This PR corrects the nodejs behavior for the code in copy_board and get_board that uses board.get_pins.
