### PR TITLE
python: tests use requests-mock instead of raw requests mocks

### DIFF
--- a/python/dev-requirements.txt
+++ b/python/dev-requirements.txt
@@ -3,3 +3,4 @@
 nose~=1.3.7
 mock~=4.0.2
 rednose~=1.3.0
+requests-mock~=1.8.0

--- a/python/tests/scripts/integration_mocks.py
+++ b/python/tests/scripts/integration_mocks.py
@@ -36,15 +36,6 @@ class IntegrationMocks(unittest.TestCase):
         print('mock_open_new: ' + uri)
         return True
 
-    def mock_requests_get(self, uri, headers=None, data=None):
-        assert False, 'Override mock_requests_get for this test to run.'
-        
-    def mock_requests_put(self, uri, headers=None, data=None):
-        assert False, 'Override mock_requests_put for this test to run.'
-        
-    def mock_requests_post(self, uri, headers=None, data=None):
-        assert False, 'Override mock_requests_post for this test to run.'
-
     def mock_input(self, prompt):
         assert False, 'Override mock_input for this test to run.'
         
@@ -52,9 +43,6 @@ class IntegrationMocks(unittest.TestCase):
         print('setUp')
         self.originals = self.monkeypatch([
             ('webbrowser', 'open_new', self.mock_open_new),
-            ('requests', 'put', self.mock_requests_put),
-            ('requests', 'post', self.mock_requests_post),
-            ('requests', 'get', self.mock_requests_get),
             ('builtins', 'input', self.mock_input)])
 
     def tearDown(self):
@@ -82,9 +70,8 @@ class IntegrationMocks(unittest.TestCase):
             for attempt in range(20): # try for 2 seconds
                 time.sleep(0) # yield so that the test thread can start
                 try:
-                    # use requests.request to avoid monkey-patched function
-                    response = requests.request(
-                        'GET',
+                    # The real_http parameter of requests_mock must be set to True for this request to work.
+                    response = requests.get(
                         'http://localhost:8085/?test-path&code=test-oauth-code',
                         allow_redirects=False)
                     print('response to redirect (301 expected): ' + str(response))

--- a/python/tests/scripts/test_analytics_api_example.py
+++ b/python/tests/scripts/test_analytics_api_example.py
@@ -1,7 +1,9 @@
 import json
 import mock
-from mock import call
+import requests
+import requests_mock
 
+from mock import call
 from integration_mocks import IntegrationMocks
 
 class AnalyticsApiExampleTest(IntegrationMocks):
@@ -10,57 +12,7 @@ class AnalyticsApiExampleTest(IntegrationMocks):
     """
     report_url_filename = 'here_is_the_filename.txt' # filename in the report url
     download_filename = 'test_report_file.txt' # filename "entered" for download
-
-    def mock_requests_post(self, uri, headers=None, json=None, allow_redirects=True):
-        # request from AsyncReport.request_report
-        print('mock_requests_post', uri, headers, json)
-        self.requests_post_calls += 1
-        response = mock.MagicMock()
-        response.__str__.return_value = '<Response [200]>'
-        response.json.return_value = {'data': {'token': 'test-report-token'}}
-        return response
-
-    def mock_requests_get(self, uri, headers=None, data=None, stream=False, allow_redirects=True):
-        print('mock_requests_get', uri, headers, data)
-        self.requests_get_calls += 1
-        report_url = f'test-report-url/x-y-z/{self.report_url_filename}?long-identifier-string'
-        response = mock.MagicMock()
-        response.__str__.return_value = '<Response [200]>'
-        if (uri == 'https://api.pinterest.com/v3/users/me/'):
-            # request from User.get
-            response.json.return_value = {'data':
-                                          {'full_name': 'test fullname',
-                                           'id': 'test_user_id',
-                                           'about': 'test about',
-                                           'profile_url': 'test profile url',
-                                           'pin_count': 'pin count'
-                                           }
-                                          }
-        elif (uri == 'https://api.pinterest.com/ads/v3/advertisers/?owner_user_id=test_user_id&include_acl=true'):
-            # request from Advertisers.get
-            response.json.return_value = {'data':
-                                          [{'name': 'test advertiser 1', 'id': 'adv_1_id'},
-                                           {'name': 'test advertiser 2', 'id': 'adv_2_id'},
-                                           {'name': 'test advertiser 3', 'id': 'adv_3_id'}
-                                           ]}
-        elif (uri == 'https://api.pinterest.com/ads/v3/resources/delivery_metrics/'):
-            # request from DeliveryMetrics.get
-            response.json.return_value = {'data':
-                                          {'metrics':
-                                           [{'name': 'CLICKTHROUGH_1', 'definition': 'clickthrough description'},
-                                            {'name': 'metric_3', 'definition': 'yet another metric'},
-                                            {'name': 'IMPRESSION_1', 'definition': 'impression description'}
-                                           ]}}
-        elif (uri == 'https://api.pinterest.com/ads/v3/reports/async/adv_2_id/delivery_metrics/?token=test-report-token'):
-            # request from AsyncReport.poll_report
-            response.json.return_value = {'data': {'report_status': 'FINISHED', 'url': report_url}}
-        elif (uri == report_url):
-            # request from generic_requests.download_file
-            response.__enter__.return_value = response # download_file uses a context manager
-            response.iter_content.return_value = ['this is the content ', 'of the report']
-        else:
-            raise ValueError(f'unexpected GET: {uri}')
-        return response
+    report_url = f'https://test-report-url/x-y-z/{report_url_filename}?long-identifier-string'
 
     def mock_input(self, prompt):
         print('mock_input', prompt)
@@ -71,13 +23,49 @@ class AnalyticsApiExampleTest(IntegrationMocks):
             return self.download_filename # check the retrieved filename and change it
         raise ValueError(f'unexpected input prompt: {prompt}')
 
-    # @mock.patch('builtins.print')
-    def test_analytics_api_example(self):
-        from scripts.analytics_api_example import main # import here to see monkeypatches
+    @requests_mock.Mocker()
+    def test_analytics_api_example(self, rm):
+        # request from AsyncReport.request_report
+        rm.post('https://api.pinterest.com/ads/v3/reports/async/adv_2_id/delivery_metrics/?start_date=2021-06-27&end_date=2021-07-27&metrics=CLICKTHROUGH_1,IMPRESSION_1&level=PIN_PROMOTION&tag_version=3',
+                json={'data': {'token': 'test-report-token'}})
 
-        self.requests_post_calls = 0
-        self.requests_get_calls = 0
-        self.input_calls = 0
+        # request from User.get
+        rm.get('https://api.pinterest.com/v3/users/me/',
+               json={'data':
+                     {'full_name': 'test fullname',
+                      'id': 'test_user_id',
+                      'about': 'test about',
+                      'profile_url': 'test profile url',
+                      'pin_count': 'pin count'
+                      }
+                     })
+        # request from Advertisers.get
+        rm.get('https://api.pinterest.com/ads/v3/advertisers/?owner_user_id=test_user_id&include_acl=true',
+               json={'data':
+                     [{'name': 'test advertiser 1', 'id': 'adv_1_id'},
+                      {'name': 'test advertiser 2', 'id': 'adv_2_id'},
+                      {'name': 'test advertiser 3', 'id': 'adv_3_id'}
+                      ]})
+
+        # request from DeliveryMetrics.get
+        rm.get('https://api.pinterest.com/ads/v3/resources/delivery_metrics/',
+               json={'data':
+                     {'metrics':
+                      [{'name': 'CLICKTHROUGH_1', 'definition': 'clickthrough description'},
+                       {'name': 'metric_3', 'definition': 'yet another metric'},
+                       {'name': 'IMPRESSION_1', 'definition': 'impression description'}
+                       ]}})
+
+        # request from AsyncReport.poll_report
+        rm.get('https://api.pinterest.com/ads/v3/reports/async/adv_2_id/delivery_metrics/?token=test-report-token',
+               json={'data': {'report_status': 'FINISHED', 'url': self.report_url}})
+
+        # request from generic_requests.download_file
+        first_chunk = 'a' * 4096 # 4096 = chunk size specified in generic_requests.download_file
+        second_chunk = 'b' * 8
+        rm.get(self.report_url, text=(first_chunk + second_chunk))
+
+        from scripts.analytics_api_example import main # import here to see monkeypatches
 
         access_token_dict = {'name': 'access_token_from_file',
                              'access_token': 'test access token from json',
@@ -92,14 +80,14 @@ class AnalyticsApiExampleTest(IntegrationMocks):
         # Mocking __enter__ provides for the open call in a context manager.
         mock_file.__enter__.return_value = mock_file
 
+        self.input_calls = 0
+
         with mock.patch('builtins.open') as mock_open:
             with mock.patch.dict('os.environ', self.mock_os_environ, clear=True):
                 mock_open.return_value = mock_file
                 main() # run analytics_api_example
                 mock_open.assert_any_call(self.download_filename, 'wb')
 
-        self.assertEqual(self.requests_post_calls, 1)
-        self.assertEqual(self.requests_get_calls, 5)
         self.assertEqual(self.input_calls, 2)
-        mock_file.write.assert_has_calls([call('this is the content '),
-                                          call('of the report')])
+        mock_file.write.assert_has_calls([call(first_chunk.encode('ascii')),
+                                          call(second_chunk.encode('ascii'))])

--- a/python/tests/scripts/test_get_access_token.py
+++ b/python/tests/scripts/test_get_access_token.py
@@ -1,58 +1,38 @@
 import mock
+import requests
+import requests_mock
 import sys
 
 from integration_mocks import IntegrationMocks
 
 class GetAccessTokenTest(IntegrationMocks):
-    def mock_requests_put(self, uri, headers=None, data=None, allow_redirects=True):
-        print('mock_requests_put', uri, headers, data)
-        self.put_uri = uri
-        self.requests_put_calls += 1
-        response = mock.MagicMock()
-        response.__str__.return_value = '<Response [200]>'
-        response.json.return_value = {'status': 'test-status',
-                                      'scope': 'test-scope',
-                                      'access_token': 'test-access-token',
-                                      'data': {'refresh_token': 'test-refresh-token'}
-                                      }
-        return response
-
-    def mock_requests_get(self, uri, headers=None, data=None, allow_redirects=True):
-        print('mock_requests_get', uri, headers, data)
-        self.get_uri = uri
-        self.requests_get_calls += 1
-        response = mock.MagicMock()
-        response.__str__.return_value = '<Response [200]>'
-        response.json.return_value = {'data':
-                                      {'full_name': 'test fullname',
-                                       'id': 'test user id',
-                                       'about': 'test about',
-                                       'profile_url': 'test profile url',
-                                       'pin_count': 'pin count'
-                                       }
-                                      }
-        return response
-
+    # real_http is required for the redirect in integration_mocks to work
+    @requests_mock.Mocker(real_http=True)
     @mock.patch('builtins.print')
-    def test_get_access_token(self, mock_print):
-        from scripts.get_access_token import main # import here to see monkeypatches
+    def test_get_access_token(self, rm, mock_print):
+        rm.put('https://api.pinterest.com/v3/oauth/access_token/',
+               json={'status': 'test-status',
+                     'scope': 'test-scope',
+                     'access_token': 'test-access-token',
+                     'data': {'refresh_token': 'test-refresh-token'}
+                     })
+        rm.get('https://api.pinterest.com/v3/users/me/',
+               json={'data':
+                     {'full_name': 'test fullname',
+                      'id': 'test user id',
+                      'about': 'test about',
+                      'profile_url': 'test profile url',
+                      'pin_count': 'pin count'
+                      }
+                     })
 
-        self.requests_put_calls = 0
-        self.requests_get_calls = 0
+        from scripts.get_access_token import main # import here to see monkeypatches
 
         with mock.patch('builtins.open') as mock_open:
             with mock.patch.dict('os.environ', self.mock_os_environ, clear=True):
                 mock_open.side_effect = FileNotFoundError # no access_token.json file
                 with self.mock_redirect():
                     main() # run get_access_token
-
-        # put called once for access_token
-        self.assertEqual(self.requests_put_calls, 1)
-        self.assertEqual(self.put_uri, 'https://api.pinterest.com/v3/oauth/access_token/')
-
-        # get called once for user data
-        self.assertEqual(self.requests_get_calls, 1)
-        self.assertEqual(self.get_uri, 'https://api.pinterest.com/v3/users/me/')
 
         # verify expected values printed. see unit tests for values
         mock_print.assert_any_call('mock_open_new: ' +

--- a/python/tests/scripts/test_get_businesses.py
+++ b/python/tests/scripts/test_get_businesses.py
@@ -1,62 +1,43 @@
 import mock
+import requests
+import requests_mock
 
 from integration_mocks import IntegrationMocks
 
 class GetBusinessesTest(IntegrationMocks):
-    def mock_requests_put(self, uri, headers=None, data=None, allow_redirects=True):
-        print('mock_requests_put', uri, headers, data, allow_redirects)
-        self.requests_put_calls += 1
-        response = mock.MagicMock()
-        response.__str__.return_value = '<Response [200]>'
-        response.json.return_value = {'status': 'test-status',
-                                      'scope': 'test-scope',
-                                      # response needs to be different each time
-                                      'access_token': 'test-access-token-' + str(self.requests_put_calls),
-                                      'data': {'refresh_token': 'test-refresh-token'}
-                                      }
-        return response
-
-    def mock_requests_get(self, uri, headers=None, data=None, allow_redirects=True):
-        print('mock_requests_get', uri, headers, data, allow_redirects)
-        response = mock.MagicMock()
-        response.__str__.return_value = '<Response [200]>'
-        if (uri == 'https://api.pinterest.com/v3/users/me/'):
-            self.requests_get_users_me_calls += 1
-            response.json.return_value = {'data':
-                                          {'full_name': 'test fullname',
-                                           'id': 'test user id',
-                                           'about': 'test about',
-                                           'profile_url': 'test profile url',
-                                           'pin_count': 'pin count'
-                                           }
-                                          }
-        elif (uri == 'https://api.pinterest.com/v3/users/me/businesses/'):
-            self.requests_get_users_me_businesses_calls += 1
-            response.json.return_value = {'data':
-                                          {'full_name': 'test business name',
-                                           'id': 'test-business-id-number'
-                                           }
-                                          }
-        return response
-
-
+    # real_http is required for the redirect in integration_mocks to work
+    @requests_mock.Mocker(real_http=True)
     @mock.patch('builtins.print')
-    def test_get_businesses(self, mock_print):
-        from scripts.get_businesses import main # import here to see monkeypatches
+    def test_get_businesses(self, rm, mock_print):
+        rm.put('https://api.pinterest.com/v3/oauth/access_token/',
+               json={'status': 'test-status',
+                     'scope': 'test-scope',
+                     'access_token': 'test-access-token',
+                     'data': {'refresh_token': 'test-refresh-token'}
+                     })
+        rm.get('https://api.pinterest.com/v3/users/me/',
+               json={'data':
+                     {'full_name': 'test fullname',
+                      'id': 'test user id',
+                      'about': 'test about',
+                      'profile_url': 'test profile url',
+                      'pin_count': 'pin count'
+                      }
+                     })
+        rm.get('https://api.pinterest.com/v3/users/me/businesses/',
+               json={'data':
+                     {'full_name': 'test business name',
+                      'id': 'test-business-id-number'
+                      }
+                     })
 
-        self.requests_put_calls = 0
-        self.requests_get_users_me_calls = 0
-        self.requests_get_users_me_businesses_calls = 0
+        from scripts.get_businesses import main # import here to see monkeypatches
 
         with mock.patch('builtins.open') as mock_open:
             with mock.patch.dict('os.environ', self.mock_os_environ, clear=True):
                 mock_open.side_effect = FileNotFoundError # no access_token.json file
                 with self.mock_redirect():
                     main() # run get_businesses
-
-        self.assertEqual(self.requests_put_calls, 1)
-        self.assertEqual(self.requests_get_users_me_calls, 1)
-        self.assertEqual(self.requests_get_users_me_businesses_calls, 1)
 
         # verify expected output
         mock_print.assert_any_call('Full Name: test fullname')

--- a/python/tests/src/v3/test_access_token.py
+++ b/python/tests/src/v3/test_access_token.py
@@ -1,45 +1,43 @@
 import unittest
 import mock
 import json
+import requests
+import requests_mock
 
 from src.v3.access_token import AccessToken
 
 class AccessTokenTest(unittest.TestCase):
 
-    @mock.patch('src.v3.access_token.requests.put')
+    @requests_mock.Mocker()
     @mock.patch('src.v3.access_token.get_auth_code')
-    def test_access_token(self, mock_get_auth_code, mock_requests_put):
+    def test_access_token(self, rm, mock_get_auth_code):
         mock_get_auth_code.return_value = 'test-auth-code'
 
         mock_api_config = mock.Mock()
         mock_api_config.app_id = 'test-app-id'
         mock_api_config.app_secret = 'test-app-secret'
-        mock_api_config.api_uri = 'test-api-uri'
+        mock_api_config.api_uri = 'https://test-api-uri'
         mock_api_config.redirect_uri = 'test-redirect-uri'
         mock_api_config.oauth_token_dir = 'test-token-dir'
         mock_api_config.version = 'v3'
         mock_api_config.verbosity = 2
 
-        mock_response = mock.MagicMock()
-        mock_response.__str__.return_value = '<Response [200]>'
-        mock_response.json.return_value = {'status': 'test-status',
-                                           'scope': 'test-scope',
-                                           'access_token': 'test-access-token',
-                                           'data': {'refresh_token': 'test-refresh-token'}
-                                           }
-        mock_requests_put.return_value = mock_response
-
+        rm.put('https://test-api-uri/v3/oauth/access_token/',
+               request_headers={'Authorization': 'Basic dGVzdC1hcHAtaWQ6dGVzdC1hcHAtc2VjcmV0'},
+               json={'status': 'test-status',
+                     'scope': 'test-scope',
+                     'access_token': 'test-access-token',
+                     'data': {'refresh_token': 'test-refresh-token'}
+                     })
         access_token = AccessToken(mock_api_config)
         access_token.oauth()
         mock_get_auth_code.assert_called_once_with(mock_api_config,
                                                    scopes=None,
                                                    refreshable=True)
-        mock_requests_put.assert_called_once_with(
-            'test-api-uri/v3/oauth/access_token/',
-            headers={'Authorization': 'Basic dGVzdC1hcHAtaWQ6dGVzdC1hcHAtc2VjcmV0'},
-            data={'code': 'test-auth-code',
-                  'redirect_uri': 'test-redirect-uri',
-                  'grant_type': 'authorization_code'})
+        self.assertEqual('code=test-auth-code' +
+                         '&redirect_uri=test-redirect-uri' +
+                         '&grant_type=authorization_code',
+                         rm.last_request.text)
 
         # header() should create a new headers dict if required
         test_header = {'Authorization': 'Bearer test-access-token'}
@@ -62,32 +60,30 @@ class AccessTokenTest(unittest.TestCase):
         self.assertEqual(access_token.hashed_refresh_token(),
                          '0a9b110d5e553bd98e9965c70a601c15c36805016ba60d54f20f5830c39edcde')
 
-        mock_response = mock.MagicMock()
-        mock_response.__str__.return_value = '<Response [200]>'
-        mock_response.json.return_value = {'access_token': 'new-access-token'}
-        mock_response.headers = {'x-pinterest-rid': 'mock-request-id'}
-        mock_requests_put.reset_mock()
-        mock_requests_put.return_value = mock_response
+        rm.put('https://test-api-uri/v3/oauth/access_token/',
+               request_headers={'Authorization': 'Basic dGVzdC1hcHAtaWQ6dGVzdC1hcHAtc2VjcmV0'},
+               headers = {'x-pinterest-rid': 'mock-request-id'},
+               json={'access_token': 'new-access-token'})
 
         # verify that refresh works by using the sha256 of 'new-access-token'
         access_token.refresh()
         # echo -n new-access-token | shasum -a 256
         self.assertEqual(access_token.hashed(),
                          '25b416c373e247768cc1a3ed4a20a13888f6b9f5288378f4756ce227d05b7710')
-        mock_requests_put.assert_called_once_with(
-            'test-api-uri/v3/oauth/access_token/',
-            headers={'Authorization': 'Basic dGVzdC1hcHAtaWQ6dGVzdC1hcHAtc2VjcmV0'},
-            data={'grant_type': 'refresh_token',
-                  'refresh_token': 'test-refresh-token'})
+        self.assertEqual('grant_type=refresh_token&refresh_token=test-refresh-token',
+                         rm.last_request.text)
 
         # verify behavior with non-default arguments:
         # - scopes passed to get_auth_code
         # - refresh raises an exception
-        mock_response.json.return_value = {'status': 'test-stats',
-                                           'scope': 'test-scope-1,test-scope-2',
-                                           'access_token': 'test-access-token',
-                                           'data': {}
-                                           }
+        rm.put('https://test-api-uri/v3/oauth/access_token/',
+               request_headers={'Authorization': 'Basic dGVzdC1hcHAtaWQ6dGVzdC1hcHAtc2VjcmV0'},
+               headers = {'x-pinterest-rid': 'mock-request-id'},
+               json={'status': 'test-status',
+                     'scope': 'test-scope-1,test-scope-2',
+                     'access_token': 'test-access-token',
+                     'data': {}
+                     })
         mock_get_auth_code.reset_mock()
         access_token = AccessToken(mock_api_config)
         access_token.oauth(scopes=['test-scope-1','test-scope-2'],

--- a/python/tests/src/v5/test_access_token.py
+++ b/python/tests/src/v5/test_access_token.py
@@ -1,35 +1,35 @@
 import unittest
 import mock
 import json
+import requests
+import requests_mock
 
 from src.v5.access_token import AccessToken
 from src.v5.oauth_scope import Scope
 
 class AccessTokenTest(unittest.TestCase):
 
-    @mock.patch('src.v5.access_token.requests.post')
+    @requests_mock.Mocker()
     @mock.patch('src.v5.access_token.get_auth_code')
-    def test_access_token(self, mock_get_auth_code, mock_requests_post):
+    def test_access_token(self, rm, mock_get_auth_code):
         mock_get_auth_code.return_value = 'test-auth-code'
 
         mock_api_config = mock.Mock()
         mock_api_config.app_id = 'test-app-id'
         mock_api_config.app_secret = 'test-app-secret'
-        mock_api_config.api_uri = 'test-api-uri'
+        mock_api_config.api_uri = 'https://test-api-uri'
         mock_api_config.redirect_uri = 'test-redirect-uri'
         mock_api_config.oauth_token_dir = 'test-token-dir'
         mock_api_config.version = 'v5'
         mock_api_config.verbosity = 2
 
-        mock_response = mock.MagicMock()
-        mock_response.__str__.return_value = '<Response [200]>'
-        mock_response.json.return_value = {'status': 'test-status',
-                                           'scope': 'test-scope',
-                                           'access_token': 'test-access-token',
-                                           'refresh_token': 'test-refresh-token'
-                                           }
-        mock_requests_post.return_value = mock_response
-
+        rm.post('https://test-api-uri/v5/oauth/token',
+                request_headers={'Authorization': 'Basic dGVzdC1hcHAtaWQ6dGVzdC1hcHAtc2VjcmV0'},
+                json={'status': 'test-status',
+                      'scope': 'test-scope',
+                      'access_token': 'test-access-token',
+                      'refresh_token': 'test-refresh-token'
+                      })
         access_token = AccessToken(mock_api_config)
         access_token.oauth()
 
@@ -41,45 +41,39 @@ class AccessTokenTest(unittest.TestCase):
         values = list(map(lambda scope: scope.value, scopes))
         # verify the scopes used by the API
         self.assertEqual(['user_accounts:read','pins:read','boards:read'], values)
+        self.assertEqual(rm.last_request.text,
+                         'code=test-auth-code' +
+                         '&redirect_uri=test-redirect-uri' +
+                         '&grant_type=authorization_code')
 
-        # mock_get_auth_code.mock_calls[0][2]['scopes'])
-        mock_requests_post.assert_called_once_with(
-            'test-api-uri/v5/oauth/token',
-            headers={'Authorization': 'Basic dGVzdC1hcHAtaWQ6dGVzdC1hcHAtc2VjcmV0'},
-            data={'code': 'test-auth-code',
-                  'redirect_uri': 'test-redirect-uri',
-                  'grant_type': 'authorization_code'})
+        rm.post('https://test-api-uri/v5/oauth/token',
+                request_headers={'Authorization': 'Basic dGVzdC1hcHAtaWQ6dGVzdC1hcHAtc2VjcmV0'},
+                headers={'x-pinterest-rid': 'mock-request-id'},
+                json={'access_token': 'pina_new-access-token',
+                      'refresh_token': 'pinr_new-refresh-token',
+                      'scope': 'users:read,pins:read,boards:read'
+                      })
 
-        mock_response = mock.MagicMock()
-        mock_response.__str__.return_value = '<Response [200]>'
-        mock_response.json.return_value = {
-            'access_token': 'pina_new-access-token',
-            'refresh_token': 'pinr_new-refresh-token',
-            'scope': 'users:read,pins:read,boards:read'
-        }
-        mock_response.headers = {'x-pinterest-rid': 'mock-request-id'}
-        mock_requests_post.reset_mock()
-        mock_requests_post.return_value = mock_response
-
-        # verify that refresh works by using the sha256 of 'new-access-token'
+        # verify that refresh works by using the sha256 of 'pina_new-access-token'
         access_token.refresh()
         # echo -n pina_new-access-token | shasum -a 256
         self.assertEqual(access_token.hashed(),
                          '4e9a163e7e33428d50c6eda1305fa8f316aa9779578944ca5db4748acd22e8d2')
-        mock_requests_post.assert_called_once_with(
-            'test-api-uri/v5/oauth/token',
-            headers={'Authorization': 'Basic dGVzdC1hcHAtaWQ6dGVzdC1hcHAtc2VjcmV0'},
-            data={'grant_type': 'refresh_token',
-                  'refresh_token': 'test-refresh-token'})
+        self.assertEqual(rm.last_request.text,
+                         'grant_type=refresh_token' +
+                         '&refresh_token=test-refresh-token')
 
         # verify behavior with non-default arguments:
         # - scopes passed to get_auth_code
         # - refresh raises an exception
-        mock_response.json.return_value = {'status': 'test-stats',
-                                           'scope': 'users:read,pins:read,boards:read',
-                                           'access_token': 'test-access-token',
-                                           'refresh_token': 'pinr_test-refresh-token',
-                                           }
+        rm.post('https://test-api-uri/v5/oauth/token',
+                request_headers={'Authorization': 'Basic dGVzdC1hcHAtaWQ6dGVzdC1hcHAtc2VjcmV0'},
+                headers={'x-pinterest-rid': 'mock-request-id'},
+                json={'status': 'test-stats',
+                      'scope': 'users:read,pins:read,boards:read',
+                      'access_token': 'test-access-token',
+                      'refresh_token': 'pinr_test-refresh-token',
+                      })
         mock_get_auth_code.reset_mock()
         access_token = AccessToken(mock_api_config)
         access_token.oauth(scopes=['test-scope-1','test-scope-2'],


### PR DESCRIPTION
Modification of the python tests, per a suggestion in a previous pull request.

Replaces raw mocks of calls to requests with the [requests-mock](https://requests-mock.readthedocs.io/en/latest/) library.
