### PR TITLE
remove user parameter for AdAnalytics

### DIFF
--- a/nodejs/scripts/get_analytics.js
+++ b/nodejs/scripts/get_analytics.js
@@ -165,8 +165,7 @@ async function main(argv) {
       results = await finder.run([]);
     } else {
       // Get advertising analytics for the appropriate kind of object.
-      const analytics = new AdAnalytics(
-        user_me_data.id, api_config, access_token)
+      const analytics = new AdAnalytics(api_config, access_token)
         .last_30_days()
         .metrics(['SPEND_IN_DOLLAR', 'TOTAL_CLICKTHROUGH'])
         .granularity('DAY');

--- a/nodejs/src/v3/analytics.js
+++ b/nodejs/src/v3/analytics.js
@@ -116,7 +116,7 @@ ${this.uri_attributes('metric_types', false)}`);
  * asynchronous report functionality.
  *
  * The attribute functions are chainable. For example:
- *    AdAnalytics(user_me_data.get('id'), api_config, access_token).attributes
+ *    AdAnalytics(api_config, access_token).attributes
  *    .last_30_days()
  *    .metrics({'SPEND_IN_DOLLAR', 'TOTAL_CLICKTHROUGH'})
  *    .granularity('DAY')
@@ -128,7 +128,7 @@ ${this.uri_attributes('metric_types', false)}`);
  * to fetch the metrics.
  */
 export class AdAnalytics extends AdAnalyticsAttributes {
-  constructor(_user_id, api_config, access_token) {
+  constructor(api_config, access_token) {
     super();
     this.api_object = new ApiObject(api_config, access_token);
     this.required_attrs.add('granularity');

--- a/nodejs/src/v3/analytics.test.js
+++ b/nodejs/src/v3/analytics.test.js
@@ -65,8 +65,7 @@ start_date=2021-03-01&end_date=2021-03-31\
   });
 
   test('v4 ads analytics', async() => {
-    const analytics = new AdAnalytics(
-      'test_user_id', 'test_api_config', 'test_access_token')
+    const analytics = new AdAnalytics('test_api_config', 'test_access_token')
       .start_date('2021-03-01')
       .end_date('2021-03-31');
 

--- a/nodejs/src/v5/analytics.js
+++ b/nodejs/src/v5/analytics.js
@@ -88,7 +88,7 @@ ${this.uri_attributes('metric_types', false)}`);
  * Pinterest API version v5.
  *
  * The attribute functions are chainable. For example:
- *    AdAnalytics(user_me_data.get('id'), api_config, access_token).attributes
+ *    AdAnalytics(api_config, access_token).attributes
  *    .last_30_days()
  *    .metrics({'SPEND_IN_DOLLAR', 'TOTAL_CLICKTHROUGH'})
  *    .granularity('DAY')
@@ -100,8 +100,7 @@ ${this.uri_attributes('metric_types', false)}`);
  * to fetch the metrics.
  */
 export class AdAnalytics extends AdAnalyticsAttributes {
-  // TODO: remove _user_id across python/nodejs, all versions
-  constructor(_user_id, api_config, access_token) {
+  constructor(api_config, access_token) {
     super();
     this.api_object = new ApiObject(api_config, access_token);
     this.required_attrs.add('granularity');

--- a/nodejs/src/v5/analytics.test.js
+++ b/nodejs/src/v5/analytics.test.js
@@ -51,8 +51,7 @@ start_date=2021-03-01&end_date=2021-03-31\
   });
 
   test('v5 ads analytics', async() => {
-    const analytics = new AdAnalytics(
-      'test_user_id', 'test_api_config', 'test_access_token')
+    const analytics = new AdAnalytics('test_api_config', 'test_access_token')
       .start_date('2021-03-01')
       .end_date('2021-03-31');
 

--- a/python/scripts/get_analytics.py
+++ b/python/scripts/get_analytics.py
@@ -138,7 +138,7 @@ def main(argv=[]):
     else:
         # Get advertising analytics for the appropriate kind of object.
         analytics = (
-            AdAnalytics(user_me_data.get("id"), api_config, access_token)
+            AdAnalytics(api_config, access_token)
             .last_30_days()
             .metrics({"SPEND_IN_DOLLAR", "TOTAL_CLICKTHROUGH"})
             .granularity("DAY")

--- a/python/src/v3/analytics.py
+++ b/python/src/v3/analytics.py
@@ -100,7 +100,7 @@ class AdAnalytics(AdAnalyticsAttributes, ApiObject):
     asynchronous report functionality.
     """
 
-    def __init__(self, _user_id, api_config, access_token):
+    def __init__(self, api_config, access_token):
         super().__init__(api_config, access_token)
         self.required_attrs.update({"granularity"})
         self.enumerated_values.update(

--- a/python/src/v5/analytics.py
+++ b/python/src/v5/analytics.py
@@ -85,7 +85,7 @@ class AdAnalytics(AdAnalyticsAttributes, ApiObject):
     Pinterest API version v5.
 
     The attribute functions are chainable. For example:
-       AdAnalytics(user_me_data.get("id"), api_config, access_token)
+       AdAnalytics(api_config, access_token)
        .last_30_days()
        .metrics({"SPEND_IN_DOLLAR", "TOTAL_CLICKTHROUGH"})
        .granularity("DAY")
@@ -97,7 +97,7 @@ class AdAnalytics(AdAnalyticsAttributes, ApiObject):
     to fetch the metrics.
     """
 
-    def __init__(self, _user_id, api_config, access_token):
+    def __init__(self, api_config, access_token):
         super().__init__(api_config, access_token)
         self.required_attrs.update({"granularity"})
 

--- a/python/tests/src/v3/test_analytics.py
+++ b/python/tests/src/v3/test_analytics.py
@@ -63,7 +63,7 @@ class AdAnalyticsTest(unittest.TestCase):
     @mock.patch("src.v5.analytics.ApiObject.__init__")
     def test_adanalytics(self, mock_init, mock_request_data):
         analytics = (
-            AdAnalytics("test_user_id", "test_api_config", "test_access_token")
+            AdAnalytics("test_api_config", "test_access_token")
             .start_date("2021-03-01")
             .end_date("2021-03-31")
         )

--- a/python/tests/src/v5/test_analytics.py
+++ b/python/tests/src/v5/test_analytics.py
@@ -55,7 +55,7 @@ class AdAnalyticsTest(unittest.TestCase):
     @mock.patch("src.v5.analytics.ApiObject.__init__")
     def test_adanalytics(self, mock_init, mock_request_data):
         analytics = (
-            AdAnalytics("test_user_id", "test_api_config", "test_access_token")
+            AdAnalytics("test_api_config", "test_access_token")
             .start_date("2021-03-01")
             .end_date("2021-03-31")
         )


### PR DESCRIPTION
This is a small change that I wanted to make simultaneously in python and nodejs once both languages had the same level of support for synchronous analytics. It removes the unused user_id parameter from the AdAnalytics constructor and related documentation.
