### PR TITLE
complete TODO tasks

### DIFF
--- a/nodejs/scripts/analytics_api_example.js
+++ b/nodejs/scripts/analytics_api_example.js
@@ -157,6 +157,7 @@ async function main(argv) {
       .last_30_days()
       .level('PIN_PROMOTION')
       .metrics(['IMPRESSION_1', 'CLICKTHROUGH_1'])
+      .filters([{ field: 'PIN_PROMOTION_STATUS', operator: '=', value: 'APPROVED' }])
       .tag_version(3);
 
     // Request (POST) and wait (GET) for the report until it is ready.

--- a/nodejs/src/v3/delivery_metrics.js
+++ b/nodejs/src/v3/delivery_metrics.js
@@ -138,9 +138,9 @@ export class DeliveryMetricsAsyncReport extends AdAnalyticsAttributes {
     return this;
   }
 
-  // TODO: not sure how filters need to be encoded.
+  // Filters must be a list of structures with fields as specified by the API.
   filters(filters) {
-    this.attrs.filters = filters;
+    this.attrs.filters = encodeURIComponent(JSON.stringify(filters));
     return this;
   }
 

--- a/nodejs/src/v3/delivery_metrics.test.js
+++ b/nodejs/src/v3/delivery_metrics.test.js
@@ -89,6 +89,13 @@ start_date=2021-03-01&end_date=2021-03-31\
     dm_async_report.metric('TOTAL_CLICK_SEARCH_QUANTITY');
     dm_async_report.metric('TOTAL_CLICK_SEARCH');
 
+    // specify filter
+    dm_async_report.filters([{
+      field: 'PIN_PROMOTION_STATUS',
+      operator: '=',
+      value: 'APPROVED'
+    }]);
+
     const mock_run = jest.spyOn(AsyncReport.prototype, 'run');
     dm_async_report.run();
 
@@ -100,6 +107,8 @@ TOTAL_CLICK_SEARCH,TOTAL_CLICK_SEARCH_QUANTITY\
 &conversion_report_time=AD_EVENT\
 &data_source=REALTIME\
 &engagement_window_days=7\
+&filters=%5B%7B%22field%22%3A%22PIN_PROMOTION_STATUS%22%2C%22\
+operator%22%3A%22%3D%22%2C%22value%22%3A%22APPROVED%22%7D%5D\
 &granularity=HOUR\
 &level=SEARCH_QUERY\
 &report_format=csv\

--- a/nodejs/src/v3/pin.js
+++ b/nodejs/src/v3/pin.js
@@ -30,7 +30,6 @@ export class Pin extends ApiObject {
 
   // https://developers.pinterest.com/docs/redoc/#operation/v3_create_pin_handler_PUT
   async create(pin_data, board_id, { section }) {
-    // TODO: carousel_data_json
     const OPTIONAL_ATTRIBUTES = [
       'alt_text',
       'description',
@@ -46,6 +45,10 @@ export class Pin extends ApiObject {
     const link = pin_data.link;
     if (link) {
       create_data.source_url = link;
+    }
+    const carousel_data = pin_data.carousel_data;
+    if (carousel_data) {
+      create_data.carousel_data_json = JSON.stringify(pin_data.carousel_data);
     }
 
     for (const key of OPTIONAL_ATTRIBUTES) {

--- a/nodejs/src/v3/pin.test.js
+++ b/nodejs/src/v3/pin.test.js
@@ -20,11 +20,28 @@ describe('v3 pin tests', () => {
     expect(mock_request_data.mock.calls[0][0]).toEqual('/v3/pins/test_pin_id/');
     expect(response).toEqual('test_response');
 
+    const carousel_data = {
+      carousel_slots: {
+        details: 'string',
+        id: 'string',
+        images: {
+          height: 450,
+          url: 'string',
+          width: 236
+        },
+        link: 'string',
+        title: 'string'
+      },
+      id: 'number in a string',
+      index: 'another number in a string'
+    };
+
     const pin_data = {
       link: 'test_pin_link',
       title: 'My Test Pin',
       alt_text: 'This is what a test pin looks like',
       ignore: 'ignored',
+      carousel_data: carousel_data,
       image_large_url: 'image_large_url_is_best_available'
     };
 
@@ -39,6 +56,7 @@ describe('v3 pin tests', () => {
       image_url: 'image_large_url_is_best_available',
       source_url: 'test_pin_link',
       title: 'My Test Pin',
+      carousel_data_json: JSON.stringify(carousel_data),
       alt_text: 'This is what a test pin looks like'
     };
     expect(mock_put_data.mock.calls[0]).toEqual(['/v3/pins/', expected_put_data]);

--- a/nodejs/src/v5/pin.js
+++ b/nodejs/src/v5/pin.js
@@ -26,7 +26,6 @@ export class Pin extends ApiObject {
 
   // https://developers.pinterest.com/docs/api/v5/#operation/pins/create
   async create(pin_data, board_id, { section }) {
-    // TODO: carousel_data_json
     const OPTIONAL_ATTRIBUTES = [
       'link',
       'title',

--- a/python/scripts/analytics_api_example.py
+++ b/python/scripts/analytics_api_example.py
@@ -161,6 +161,9 @@ def main(argv=[]):
         .last_30_days()
         .level("PIN_PROMOTION")
         .metrics({"IMPRESSION_1", "CLICKTHROUGH_1"})
+        .filters(
+            [{"field": "PIN_PROMOTION_STATUS", "operator": "=", "value": "APPROVED"}]
+        )
         .tag_version(3)
     )
 

--- a/python/src/arguments.py
+++ b/python/src/arguments.py
@@ -9,11 +9,17 @@ def positive_integer(number):
     return ivalue
 
 
-# TODO: use parent parser.
-#       see https://docs.python.org/3/library/argparse.html for details.
 def common_arguments(parser):
     """
     Set command line arguments that are common to all of the scripts.
+
+    This function should be called after adding arguments, so that the common
+    arguments are at the end of the argument list printed as part of the help
+    message.
+
+    If this function were implemented as a parent parser, then the common
+    arguments would always appear at the beginning of the list provided in the
+    command-line help.
     """
     parser.add_argument("-a", "--access-token", help="access token name")
     parser.add_argument(

--- a/python/src/v3/delivery_metrics.py
+++ b/python/src/v3/delivery_metrics.py
@@ -1,3 +1,6 @@
+import json
+from urllib.parse import quote
+
 from analytics_attributes import AdAnalyticsAttributes
 from api_object import ApiObject
 from v3.async_report import AsyncReport
@@ -149,8 +152,12 @@ class DeliveryMetricsAsyncReport(AdAnalyticsAttributes, AsyncReport):
         return self
 
     def filters(self, filters):
-        raise "TODO: not sure how filters need to be encoded"
-        self.attrs["filters"] = filters
+        """
+        Filters must be a list of structures with fields as specified by the API.
+        JSON separators are set to eliminate whitespace and to get the most
+        compact JSON representation.
+        """
+        self.attrs["filters"] = quote(json.dumps(filters, separators=(",", ":")))
         return self
 
     def report_format(self, report_format):

--- a/python/src/v3/pin.py
+++ b/python/src/v3/pin.py
@@ -1,3 +1,5 @@
+import json
+
 from api_object import ApiObject
 
 
@@ -27,7 +29,6 @@ class Pin(ApiObject):
 
     # https://developers.pinterest.com/docs/redoc/#operation/v3_create_pin_handler_PUT
     def create(self, pin_data, board_id, section=None):
-        # TODO: carousel_data_json
         OPTIONAL_ATTRIBUTES = [
             "alt_text",
             "description",
@@ -39,6 +40,11 @@ class Pin(ApiObject):
         link = pin_data.get("link")
         if link:
             create_data["source_url"] = link
+        carousel_data = pin_data.get("carousel_data")
+        if carousel_data:
+            create_data["carousel_data_json"] = json.dumps(
+                carousel_data, separators=(",", ":")
+            )
 
         for key in OPTIONAL_ATTRIBUTES:
             value = pin_data.get(key)

--- a/python/src/v5/pin.py
+++ b/python/src/v5/pin.py
@@ -23,7 +23,6 @@ class Pin(ApiObject):
 
     # https://developers.pinterest.com/docs/api/v5/#operation/pins/create
     def create(self, pin_data, board_id, section=None):
-        # TODO: carousel_data_json
         OPTIONAL_ATTRIBUTES = [
             "link",
             "title",

--- a/python/tests/scripts/test_analytics_api_example.py
+++ b/python/tests/scripts/test_analytics_api_example.py
@@ -36,7 +36,9 @@ class AnalyticsApiExampleTest(IntegrationMocks):
             r"https://api.pinterest.com/ads/v3/reports/async/adv_2_id/delivery_metrics/"
             r"\?start_date=2\d{3}-[01]\d-[0123]\d"
             r"&end_date=2\d{3}-[01]\d-[0123]\d"
-            r"&metrics=CLICKTHROUGH_1,IMPRESSION_1&level=PIN_PROMOTION&tag_version=3"
+            r"&metrics=CLICKTHROUGH_1,IMPRESSION_1"
+            r"&filters=[%0-9a-zA-z]+"
+            r"&level=PIN_PROMOTION&tag_version=3"
         )
         rm.post(matcher, json={"data": {"token": "test-report-token"}})
 

--- a/python/tests/src/v3/test_delivery_metrics.py
+++ b/python/tests/src/v3/test_delivery_metrics.py
@@ -96,6 +96,11 @@ class DeliveryMetricsAsyncReportTest(unittest.TestCase):
         dm_async_report.metric("TOTAL_CLICK_SEARCH_QUANTITY")
         dm_async_report.metric("TOTAL_CLICK_SEARCH")
 
+        # specify filter
+        dm_async_report.filters(
+            [{"field": "PIN_PROMOTION_STATUS", "operator": "=", "value": "APPROVED"}]
+        )
+
         uri_attributes = dm_async_report.post_uri_attributes()
         self.assertEqual(
             uri_attributes,
@@ -106,6 +111,8 @@ class DeliveryMetricsAsyncReportTest(unittest.TestCase):
             + "&conversion_report_time=AD_EVENT"
             + "&data_source=REALTIME"
             + "&engagement_window_days=7"
+            + "&filters=%5B%7B%22field%22%3A%22PIN_PROMOTION_STATUS%22%2C%22"
+            + "operator%22%3A%22%3D%22%2C%22value%22%3A%22APPROVED%22%7D%5D"
             + "&granularity=HOUR"
             + "&level=SEARCH_QUERY"
             + "&report_format=csv"

--- a/python/tests/src/v3/test_pin.py
+++ b/python/tests/src/v3/test_pin.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 
 import mock
@@ -35,11 +36,23 @@ class PinTest(unittest.TestCase):
 
         put_data_return_value = {"id": "new_pin_id"}
         mock_api_object_put_data.return_value = put_data_return_value
+        carousel_data = {
+            "carousel_slots": {
+                "details": "string",
+                "id": "string",
+                "images": {"height": 450, "url": "string", "width": 236},
+                "link": "string",
+                "title": "string",
+            },
+            "id": "number in a string",
+            "index": "another number in a string",
+        }
         new_pin_data = {
             "alt_text": "test alt text",
             "description": "test description",
             "link": "test://domain/path1/path2/webpage.html",
             "image_large_url": "test://domain/path1/path2/image.jpg",
+            "carousel_data": carousel_data,
         }
         expected_put_data = {
             "board_id": "test_board_id",
@@ -47,6 +60,7 @@ class PinTest(unittest.TestCase):
             "source_url": new_pin_data["link"],
             "alt_text": new_pin_data["alt_text"],
             "description": new_pin_data["description"],
+            "carousel_data_json": json.dumps(carousel_data, separators=(",", ":")),
         }
         response = test_pin.create(new_pin_data, "test_board_id")
         self.assertEqual(response, put_data_return_value)


### PR DESCRIPTION
This PR removes all of the TODO comments from the quickstart by making the following changes:
* declaring that implementing common_arguments as a function is better than implementing a parent parser
* implementing pin carousel_data for v3
* removing the carousel_data TODO for v5, because carousel_data is not supported in v5
* implementing delivery metric filters
* provide unit tests for new functionality
