### PR TITLE
nodejs: remove lint formatter with vulnerability

### DIFF
--- a/nodejs/Makefile
+++ b/nodejs/Makefile
@@ -4,9 +4,5 @@ tests:
 lint:
 	DEBUG=eslint:cli-engine yarn run eslint src scripts
 
-# fails when there are no errors
-lint-summary:
-	yarn run eslint --format summary-chart src scripts
-
 lint-fix:
 	yarn run eslint --fix src scripts

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -16,7 +16,6 @@
     "babel-jest": "^27.0.1",
     "eslint": "^7.31.0",
     "eslint-config-standard": "^16.0.3",
-    "eslint-formatter-summary-chart": "^0.2.1",
     "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-jest": "^24.4.0",
     "eslint-plugin-node": "^11.1.0",


### PR DESCRIPTION
I kind of liked the eslint summary formatter, but it's kind of brittle and (more importantly) npm just informed me that it has a vulnerability in one if its dependencies. So, I'm removing this highly-optional component.
