### PR TITLE
TPP-1582: need to support new v5 analytics attributes

### DIFF
--- a/nodejs/src/analytics_attributes.js
+++ b/nodejs/src/analytics_attributes.js
@@ -213,8 +213,7 @@ export class AdAnalyticsAttributes extends AnalyticsAttributes {
       granularity: ['TOTAL', 'DAY', 'HOUR', 'WEEK', 'MONTH'],
       click_window_days: ENUMERATED_WINDOW_DAYS,
       engagement_window_days: ENUMERATED_WINDOW_DAYS,
-      view_window_days: ENUMERATED_WINDOW_DAYS,
-      conversion_report_time: ['AD_EVENT', 'CONVERSION_EVENT']
+      view_window_days: ENUMERATED_WINDOW_DAYS
     });
   }
 

--- a/nodejs/src/v3/analytics.js
+++ b/nodejs/src/v3/analytics.js
@@ -132,8 +132,10 @@ export class AdAnalytics extends AdAnalyticsAttributes {
     super();
     this.api_object = new ApiObject(api_config, access_token);
     this.required_attrs.add('granularity');
+    // https://developers.pinterest.com/docs/redoc/combined_reporting/#operation/ads_v3_create_advertiser_delivery_metrics_report_POST
     Object.assign(this.enumerated_values, {
-      attribution_types: ['INDIVIDUAL', 'HOUSEHOLD']
+      attribution_types: ['INDIVIDUAL', 'HOUSEHOLD'],
+      conversion_report_time: ['AD_EVENT', 'CONVERSION_EVENT']
     });
   }
 

--- a/nodejs/src/v5/analytics.js
+++ b/nodejs/src/v5/analytics.js
@@ -104,6 +104,10 @@ export class AdAnalytics extends AdAnalyticsAttributes {
     super();
     this.api_object = new ApiObject(api_config, access_token);
     this.required_attrs.add('granularity');
+    Object.assign(this.enumerated_values, {
+      // https://developers.pinterest.com/docs/api/v5/#operation/ad_account/analytics
+      conversion_report_time: ['TIME_OF_AD_ACTION', 'TIME_OF_CONVERSION']
+    });
   }
 
   async request(request_uri) {

--- a/nodejs/src/v5/analytics.test.js
+++ b/nodejs/src/v5/analytics.test.js
@@ -113,7 +113,7 @@ ad_group_ids=test_ad_group\
 &engagement_window_days=14\
 &granularity=HOUR');
 
-    analytics.view_window_days(60).conversion_report_time('AD_EVENT');
+    analytics.view_window_days(60).conversion_report_time('TIME_OF_CONVERSION');
     expect(await analytics.get_ad(
       'test_ad_account', 'test_campaign', 'test_ad_group', 'test_ad'))
       .toEqual('test_response');
@@ -124,7 +124,7 @@ ad_ids=test_ad\
 &start_date=2021-03-01&end_date=2021-03-31\
 &columns=SPEND_IN_DOLLAR,TOTAL_CLICKTHROUGH\
 &click_window_days=7\
-&conversion_report_time=AD_EVENT\
+&conversion_report_time=TIME_OF_CONVERSION\
 &engagement_window_days=14\
 &granularity=HOUR\
 &view_window_days=60');

--- a/python/src/analytics_attributes.py
+++ b/python/src/analytics_attributes.py
@@ -207,7 +207,6 @@ class AdAnalyticsAttributes(AnalyticsAttributes):
                 "click_window_days": self.ENUMERATED_WINDOW_DAYS,
                 "engagement_window_days": self.ENUMERATED_WINDOW_DAYS,
                 "view_window_days": self.ENUMERATED_WINDOW_DAYS,
-                "conversion_report_time": {"AD_EVENT", "CONVERSION_EVENT"},
             }
         )
 

--- a/python/src/v3/analytics.py
+++ b/python/src/v3/analytics.py
@@ -104,7 +104,11 @@ class AdAnalytics(AdAnalyticsAttributes, ApiObject):
         super().__init__(api_config, access_token)
         self.required_attrs.update({"granularity"})
         self.enumerated_values.update(
-            {"attribution_types": {"INDIVIDUAL", "HOUSEHOLD"}}
+            # https://developers.pinterest.com/docs/redoc/combined_reporting/#operation/ads_v3_create_advertiser_delivery_metrics_report_POST
+            {
+                "attribution_types": {"INDIVIDUAL", "HOUSEHOLD"},
+                "conversion_report_time": {"AD_EVENT", "CONVERSION_EVENT"},
+            }
         )
 
     def request(self, request_uri):

--- a/python/src/v5/analytics.py
+++ b/python/src/v5/analytics.py
@@ -100,6 +100,10 @@ class AdAnalytics(AdAnalyticsAttributes, ApiObject):
     def __init__(self, api_config, access_token):
         super().__init__(api_config, access_token)
         self.required_attrs.update({"granularity"})
+        self.enumerated_values.update(
+            # https://developers.pinterest.com/docs/api/v5/#operation/ad_account/analytics
+            {"conversion_report_time": {"TIME_OF_AD_ACTION", "TIME_OF_CONVERSION"}}
+        )
 
     def request(self, request_uri):
         return self.request_data(request_uri + self.uri_attributes("columns", True))

--- a/python/tests/src/v5/test_analytics.py
+++ b/python/tests/src/v5/test_analytics.py
@@ -115,7 +115,7 @@ class AdAnalyticsTest(unittest.TestCase):
         )
         mock_request_data.reset_mock()
 
-        analytics.view_window_days(60).conversion_report_time("AD_EVENT")
+        analytics.view_window_days(60).conversion_report_time("TIME_OF_CONVERSION")
         self.assertEqual(
             "test_response",
             analytics.get_ad(
@@ -128,7 +128,7 @@ class AdAnalyticsTest(unittest.TestCase):
             "&start_date=2021-03-01&end_date=2021-03-31"
             "&columns=SPEND_IN_DOLLAR,TOTAL_CLICKTHROUGH"
             "&click_window_days=7"
-            "&conversion_report_time=AD_EVENT"
+            "&conversion_report_time=TIME_OF_CONVERSION"
             "&engagement_window_days=14"
             "&granularity=HOUR"
             "&view_window_days=60"


### PR DESCRIPTION
Fixing issue reported to Pinterest support by a developer: the v5 analytics API has different values for `conversion_report_time` than the v3 analytics API.
