### PR TITLE
TPP-1561: support https proxy agent

### DIFF
--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -444,6 +444,19 @@ optional arguments:
                         version of the API to use
 ```
 
+## Proxy Configuration
+
+The quickstart uses the [global-agent](https://www.npmjs.com/package/global-agent) package to support proxy configurations. To forward Pinterest API requests through a local proxy at port 8080, run this command in the shell before running any of the above commands:
+```
+$ export GLOBAL_AGENT_HTTPS_PROXY="http://localhost:8080"
+```
+
+According to the [global-agent documentation](https://github.com/gajus/global-agent#what-is-the-reason-global-agentbootstrap-does-not-use-http_proxy), it's also possible to use the more standard HTTPS_PROXY environment variable as follows:
+```
+$ export GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE=
+$ export HTTPS_PROXY="http://localhost:8080"
+```
+
 ## Tests
 
 Unit tests use the [Jest framework](https://jestjs.io/) and are in the `*.test.js` files that correspond to each source file. In addition, the [Babel JavaScript compiler](https://babeljs.io/) is required for Jest to run with the module structure used in this repo. The node dependencies for Jest should have been installed as part of the quickstart instructure, Unless you specified the `--production` flag with ```npm install```. To install the `jest` binary, you'll need to run `npm install jest --global` once on your development machine. (These instructions were written when the latest version of `jest` was 27.0.3). Then, run the tests with the `jest` command. No arguments are required, but you can specify the relative pathname of a test file as an argument. For example: `jest ./src/v3/user.test.js`

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "argparse": "^2.0.1",
     "enum": "^3.0.4",
+    "global-agent": "^3.0.0",
     "got": "^11.8.2",
     "open": "^8.0.2",
     "readline": "^1.3.0",

--- a/nodejs/src/api_config.js
+++ b/nodejs/src/api_config.js
@@ -1,4 +1,5 @@
 import process from 'process';
+import { bootstrap } from 'global-agent';
 
 export class ApiConfig {
   constructor({ verbosity = 2, version }) {
@@ -37,6 +38,9 @@ export class ApiConfig {
     // swizzle oauth and api hosts, based on environment
     this.oauth_uri = process.env.PINTEREST_OAUTH_URI || DEFAULT_OAUTH_URI;
     this.api_uri = process.env.PINTEREST_API_URI || DEFAULT_API_URI;
+
+    // start the global-agent to take care of any required proxies
+    bootstrap();
   }
 
   /**

--- a/python/README.md
+++ b/python/README.md
@@ -432,6 +432,13 @@ optional arguments:
                         version of the API to use
 ```
 
+## Proxy Configuration
+
+The quickstart uses the [Python Requests](https://docs.python-requests.org) library, which supports the `HTTPS_PROXY` environment variable. For example, to forward Pinterest API requests through a local proxy at port 8080, run this command in the shell before running any of the above commands:
+```
+$ export HTTPS_PROXY="http://localhost:8080"
+```
+
 ## Tests
 
 Unit tests are in `./tests/src/` and integrations tests are in `./tests/scripts/`. To run the tests, run the following commands in your virtualenv:


### PR DESCRIPTION
This pull request implements https proxy agent functionality for nodejs, and documents the functionality for both python and nodejs. (https proxy agents were already supported in python, but this functionality was undocumented.)

This functionality was requested by @mingxin-yang in issue #33.
