### PR TITLE
migrate from /ads/v3 to /ads/v4

### DIFF
--- a/nodejs/scripts/analytics_api_example.js
+++ b/nodejs/scripts/analytics_api_example.js
@@ -156,6 +156,7 @@ async function main(argv) {
       api_config, access_token, advertiser_id)
       .last_30_days()
       .level('PIN_PROMOTION')
+      .granularity('DAY')
       .metrics(['IMPRESSION_1', 'CLICKTHROUGH_1'])
       .filters([{ field: 'PIN_PROMOTION_STATUS', operator: '=', value: 'APPROVED' }])
       .tag_version(3);

--- a/nodejs/src/analytics_attributes.js
+++ b/nodejs/src/analytics_attributes.js
@@ -151,7 +151,11 @@ export class AnalyticsAttributes {
   // Returns the metrics as a comma-separated string, suitable
   // for a GET or POST parameter.
   metrics_string(required) {
-    return this.metrics_array(required).join(',');
+    const metrics_array = this.metrics_array(required);
+    if (metrics_array) {
+      return metrics_array.join(',');
+    }
+    return '';
   }
 
   // check all of the attributes
@@ -207,13 +211,13 @@ export class AnalyticsAttributes {
   data_attributes(metrics_parameter, metrics_required) {
     this.verify_attributes(metrics_required);
 
-    let attributes = {
+    const attributes = {
       start_date: this._start_date,
       end_date: this._end_date
     };
 
     const metrics_array = this.metrics_array(metrics_required);
-    if (metrics_array && (metrics_array.length > 0)) {
+    if (metrics_array && metrics_array.length > 0) {
       attributes[metrics_parameter] = metrics_array;
     }
 

--- a/nodejs/src/analytics_attributes.js
+++ b/nodejs/src/analytics_attributes.js
@@ -132,9 +132,8 @@ export class AnalyticsAttributes {
     return this;
   }
 
-  // Returns the metrics as a comma-separated string, suitable
-  // for a GET or POST parameter.
-  metrics_string(required) {
+  // Returns the metrics as a sorted array.
+  metrics_array(required) {
     if (this._metrics.size === 0) {
       // throw an exception if metrics are required but not set
       if (required) {
@@ -146,7 +145,13 @@ export class AnalyticsAttributes {
     // set order is nondeterministic, so create a sorted array
     const metrics_array = Array.from(this._metrics);
     metrics_array.sort(); // sort makes error testing and debugging easier
-    return metrics_array.join(',');
+    return metrics_array;
+  }
+
+  // Returns the metrics as a comma-separated string, suitable
+  // for a GET or POST parameter.
+  metrics_string(required) {
+    return this.metrics_array(required).join(',');
   }
 
   // check all of the attributes
@@ -193,6 +198,27 @@ export class AnalyticsAttributes {
     for (const attr of attr_array) {
       attributes += `&${attr}=${this.attrs[attr]}`;
     }
+
+    return attributes;
+  }
+
+  // Provides the attributes as a structure that can be sent
+  // in POST data.
+  data_attributes(metrics_parameter, metrics_required) {
+    this.verify_attributes(metrics_required);
+
+    let attributes = {
+      start_date: this._start_date,
+      end_date: this._end_date
+    };
+
+    const metrics_array = this.metrics_array(metrics_required);
+    if (metrics_array && (metrics_array.length > 0)) {
+      attributes[metrics_parameter] = metrics_array;
+    }
+
+    // put other attributes into the object
+    Object.assign(attributes, this.attrs);
 
     return attributes;
   }

--- a/nodejs/src/v3/advertisers.js
+++ b/nodejs/src/v3/advertisers.js
@@ -50,17 +50,18 @@ export class Advertisers extends ApiObject {
   // Get the ad groups associated with an Ad Account and Campaign.
   // https://developers.pinterest.com/docs/redoc/adtech_ads_v4/#operation/get_ad_groups_handler
   async get_ad_groups(ad_account_id, campaign_id, query_parameters) {
-    let qp = Object.assign({}, query_parameters);
-    qp.campaign_ids = [campaign_id];
-    return this.get_iterator(`/ads/v4/advertisers/${ad_account_id}/ad_groups`, qp);
+    return this.get_iterator(
+      `/ads/v4/advertisers/${ad_account_id}/ad_groups?campaign_ids=${campaign_id}`,
+      query_parameters
+    );
   }
 
   // Get the ads associated with an Ad Account, Campaign, and Ad Group.
   // https://developers.pinterest.com/docs/redoc/adtech_ads_v4/#operation/get_ads_handler
   async get_ads(ad_account_id, campaign_id, ad_group_id, query_parameters) {
-    let qp = Object.assign({}, query_parameters);
-    qp.campaign_ids = [campaign_id];
-    qp.ad_group_ids = [ad_group_id];
-    return this.get_iterator(`/ads/v4/advertisers/${ad_account_id}/ads`, qp);
+    return this.get_iterator(`\
+/ads/v4/advertisers/${ad_account_id}/ads\
+?campaign_ids=${campaign_id}&ad_group_ids=${ad_group_id}`,
+    query_parameters);
   }
 }

--- a/nodejs/src/v3/advertisers.js
+++ b/nodejs/src/v3/advertisers.js
@@ -9,12 +9,12 @@ export class Advertisers extends ApiObject {
   // Get the advertisers shared with the specified user_id.
   // It's unintuitive, but the param include_acl=true is required
   // to return advertisers which are shared with your account.
-  // https://developers.pinterest.com/docs/redoc/#operation/ads_v3_get_advertisers_by_owner_user_id_handler_GET
+  // https://developers.pinterest.com/docs/redoc/adtech_ads_v4/#operation/get_advertisers_handler
   async get(query_parameters) {
     // query_parameters are available for consistency with other endpoints.
     // There are no other query_parameters available for this endpoint.
     return this.get_iterator(
-      `/ads/v3/advertisers/?owner_user_id=${this.user_id}&include_acl=true`,
+      `/ads/v4/advertisers/?owner_user_id=${this.user_id}&include_acl=true`,
       query_parameters);
   }
 
@@ -41,23 +41,26 @@ export class Advertisers extends ApiObject {
   }
 
   // Get the campaigns associated with an Ad Account.
-  // https://developers.pinterest.com/docs/redoc/#operation/ads_v3_get_advertiser_campaigns_handler_GET
+  // https://developers.pinterest.com/docs/redoc/adtech_ads_v4/#operation/get_campaigns_handler
   async get_campaigns(ad_account_id, query_parameters) {
-    return this.get_iterator(`/ads/v3/advertisers/${ad_account_id}/campaigns/`,
+    return this.get_iterator(`/ads/v4/advertisers/${ad_account_id}/campaigns`,
       query_parameters);
   }
 
   // Get the ad groups associated with an Ad Account and Campaign.
-  // https://developers.pinterest.com/docs/redoc/#operation/ads_v3_get_campaign_ad_groups_handler_GET
-  async get_ad_groups(_ad_account_id, campaign_id, query_parameters) {
-    return this.get_iterator(`/ads/v3/campaigns/${campaign_id}/ad_groups/`,
-      query_parameters);
+  // https://developers.pinterest.com/docs/redoc/adtech_ads_v4/#operation/get_ad_groups_handler
+  async get_ad_groups(ad_account_id, campaign_id, query_parameters) {
+    let qp = Object.assign({}, query_parameters);
+    qp.campaign_ids = [campaign_id];
+    return this.get_iterator(`/ads/v4/advertisers/${ad_account_id}/ad_groups`, qp);
   }
 
   // Get the ads associated with an Ad Account, Campaign, and Ad Group.
-  // https://developers.pinterest.com/docs/redoc/#operation/ads_v3_get_ad_group_pin_promotions_handler_GET
-  async get_ads(_ad_account_id, _campaign_id, ad_group_id, query_parameters) {
-    return this.get_iterator(`/ads/v3/ad_groups/${ad_group_id}/pin_promotions/`,
-      query_parameters);
+  // https://developers.pinterest.com/docs/redoc/adtech_ads_v4/#operation/get_ads_handler
+  async get_ads(ad_account_id, campaign_id, ad_group_id, query_parameters) {
+    let qp = Object.assign({}, query_parameters);
+    qp.campaign_ids = [campaign_id];
+    qp.ad_group_ids = [ad_group_id];
+    return this.get_iterator(`/ads/v4/advertisers/${ad_account_id}/ads`, qp);
   }
 }

--- a/nodejs/src/v3/advertisers.test.js
+++ b/nodejs/src/v3/advertisers.test.js
@@ -19,7 +19,7 @@ describe('v3 advertisers tests', () => {
 
     let response = await adv.get();
     expect(mock_get_iterator.mock.calls[0]).toEqual([
-      '/ads/v3/advertisers/?owner_user_id=test_user&include_acl=true',
+      '/ads/v4/advertisers/?owner_user_id=test_user&include_acl=true',
       undefined]);
     expect(response).toEqual('test_iterator');
 
@@ -44,21 +44,22 @@ describe('v3 advertisers tests', () => {
 
     response = await adv.get_campaigns('ad_account_1', 'query_parameters_1');
     expect(mock_get_iterator.mock.calls[1]).toEqual([
-      '/ads/v3/advertisers/ad_account_1/campaigns/',
+      '/ads/v4/advertisers/ad_account_1/campaigns',
       'query_parameters_1']);
     expect(response).toEqual('test_iterator');
 
     response = await adv.get_ad_groups('ad_account_2', 'campaign_2');
     expect(mock_get_iterator.mock.calls[2]).toEqual([
-      '/ads/v3/campaigns/campaign_2/ad_groups/',
+      '/ads/v4/advertisers/ad_account_2/ad_groups?campaign_ids=campaign_2',
       undefined]);
     expect(response).toEqual('test_iterator');
 
     response = await adv.get_ads('ad_account_3', 'campaign_3', 'ad_group_3',
       'query_parameters_3');
-    expect(mock_get_iterator.mock.calls[3]).toEqual([
-      '/ads/v3/ad_groups/ad_group_3/pin_promotions/',
-      'query_parameters_3']);
+    expect(mock_get_iterator.mock.calls[3]).toEqual(['\
+/ads/v4/advertisers/ad_account_3/ads?\
+campaign_ids=campaign_3&ad_group_ids=ad_group_3',
+    'query_parameters_3']);
     expect(response).toEqual('test_iterator');
   });
 });

--- a/nodejs/src/v3/async_report.js
+++ b/nodejs/src/v3/async_report.js
@@ -15,11 +15,11 @@ export class AsyncReport extends ApiObject {
   }
 
   // For documentation, see:
-  // https://developers.pinterest.com/docs/redoc/combined_reporting/#operation/ads_v3_create_advertiser_delivery_metrics_report_POST
+  // https://developers.pinterest.com/docs/redoc/adtech_ads_v4/#operation/create_async_delivery_metrics_handler
   async request_report(post_data_attributes) {
     // create path and set required attributes
     const path = `\
-/ads/v4/advertisers/${this.advertiser_id}/${this.kind_of}/async/`;
+/ads/v4/advertisers/${this.advertiser_id}/${this.kind_of}/async`;
 
     this.token = (await this.post_data(path, post_data_attributes)).token;
     return this.token; // so that tests can verify the token
@@ -28,10 +28,10 @@ export class AsyncReport extends ApiObject {
   // Executes a single GET request to retrieve the status and (if available)
   // the URL for the report.
   // For documentation, see:
-  //   https://developers.pinterest.com/docs/redoc/combined_reporting/#operation/ads_v3_get_advertiser_delivery_metrics_report_handler_GET
+  //   https://developers.pinterest.com/docs/redoc/adtech_ads_v4/#operation/get_async_delivery_metrics_handler
   async poll_report() {
     const path = `\
-/ads/v4/advertisers/${this.advertiser_id}/${this.kind_of}/async/\
+/ads/v4/advertisers/${this.advertiser_id}/${this.kind_of}/async\
 ?token=${this.token}`;
 
     const poll_data = await this.request_data(path);

--- a/nodejs/src/v3/async_report.js
+++ b/nodejs/src/v3/async_report.js
@@ -16,13 +16,12 @@ export class AsyncReport extends ApiObject {
 
   // For documentation, see:
   // https://developers.pinterest.com/docs/redoc/combined_reporting/#operation/ads_v3_create_advertiser_delivery_metrics_report_POST
-  async request_report(uri_attributes) {
+  async request_report(post_data_attributes) {
     // create path and set required attributes
     const path = `\
-/ads/v3/reports/async/${this.advertiser_id}/${this.kind_of}/?\
-${uri_attributes}`;
+/ads/v4/advertisers/${this.advertiser_id}/${this.kind_of}/async/`;
 
-    this.token = (await this.post_data(path)).token;
+    this.token = (await this.post_data(path, post_data_attributes)).token;
     return this.token; // so that tests can verify the token
   }
 
@@ -32,7 +31,7 @@ ${uri_attributes}`;
   //   https://developers.pinterest.com/docs/redoc/combined_reporting/#operation/ads_v3_get_advertiser_delivery_metrics_report_handler_GET
   async poll_report() {
     const path = `\
-/ads/v3/reports/async/${this.advertiser_id}/${this.kind_of}/\
+/ads/v4/advertisers/${this.advertiser_id}/${this.kind_of}/async/\
 ?token=${this.token}`;
 
     const poll_data = await this.request_data(path);
@@ -58,8 +57,8 @@ ${uri_attributes}`;
 
   // Executes the POST request to initiate the report and then the GET requests
   // to retrieve the report.
-  async run(uri_attributes) {
-    await this.request_report(uri_attributes);
+  async run(attributes) {
+    await this.request_report(attributes);
     await this.wait_report();
   }
 

--- a/nodejs/src/v3/async_report.test.js
+++ b/nodejs/src/v3/async_report.test.js
@@ -20,9 +20,10 @@ describe('async report tests', () => {
     await test_report1.request_report('test_report1_attributes');
 
     expect(test_report1.token).toEqual('test_report1_token');
-    expect(mock_post_data.mock.calls).toEqual([['\
-/ads/v3/reports/async/test_advertiser_id/test_report1/\
-?test_report1_attributes']]);
+    expect(mock_post_data.mock.calls).toEqual([
+      ['/ads/v4/advertisers/test_advertiser_id/test_report1/async',
+        'test_report1_attributes']
+    ]);
 
     const mock_request_data = jest.spyOn(ApiObject.prototype, 'request_data');
     mock_request_data.mockResolvedValueOnce({
@@ -32,7 +33,7 @@ describe('async report tests', () => {
     await test_report1.wait_report();
     expect(test_report1.url()).toEqual('test_report1_url');
     expect(mock_request_data.mock.calls).toEqual([['\
-/ads/v3/reports/async/test_advertiser_id/test_report1/\
+/ads/v4/advertisers/test_advertiser_id/test_report1/async\
 ?token=test_report1_token']]);
   });
 
@@ -96,12 +97,13 @@ test_report2_url/x-y-z/metrics_report.txt?Very-long-credentials-string';
 
     expect(test_report2.url()).toEqual(test_report2_url); // verify returned URL
     // verify API requests
-    expect(mock_post_data.mock.calls).toEqual([['\
-/ads/v3/reports/async/test_advertiser_id/test_report2/\
-?test_report2_attributes']]);
+    expect(mock_post_data.mock.calls).toEqual([
+      ['/ads/v4/advertisers/test_advertiser_id/test_report2/async',
+        'test_report2_attributes']
+    ]);
     // request data will be called multiple times
     expect(mock_request_data).toHaveBeenCalledWith('\
-/ads/v3/reports/async/test_advertiser_id/test_report2/\
+/ads/v4/advertisers/test_advertiser_id/test_report2/async\
 ?token=test_report2_token');
 
     // verify filename

--- a/nodejs/src/v3/delivery_metrics.js
+++ b/nodejs/src/v3/delivery_metrics.js
@@ -54,6 +54,7 @@ export class DeliveryMetrics extends ApiObject {
  *          .start_date('2021-03-01') \
  *          .end_date('2021-03-31') \
  *          .level('PIN_PROMOTION') \
+ *          .granularity('DAY') \
  *          .metrics({'IMPRESSION_1', 'CLICKTHROUGH_1'}) \
  *          .report_format('csv')
  *

--- a/nodejs/src/v3/delivery_metrics.js
+++ b/nodejs/src/v3/delivery_metrics.js
@@ -17,13 +17,13 @@ export class DeliveryMetrics extends ApiObject {
   // should be called automagically. See:
   //   https://eslint.org/docs/rules/no-useless-constructor
 
-  // https://developers.pinterest.com/docs/redoc/#operation/ads_v3_get_delivery_metrics_handler_GET
+  // https://developers.pinterest.com/docs/redoc/adtech_ads_v4/#operation/get_available_metrics_definition_handler
   // Get the full list of all available delivery metrics.
   // This call is not used much in day-to-day API code, but is a useful endpoint
   // for learning about the metrics.
   async get() {
     return (await this.request_data(
-      '/ads/v3/resources/delivery_metrics/')).metrics;
+      '/ads/v4/resources/delivery_metrics')).metrics;
   }
 
   summary(delivery_metric) {
@@ -47,7 +47,7 @@ export class DeliveryMetrics extends ApiObject {
 /**
  * Specifies all of the attributes for the async advertiser
  * delivery metrics report. For more information, see:
- *    https://developers.pinterest.com/docs/redoc/combined_reporting/#operation/ads_v3_create_advertiser_delivery_metrics_report_POST
+ *    https://developers.pinterest.com/docs/redoc/adtech_ads_v4/#operation/create_async_delivery_metrics_handler
  *
  * The attribute functions are chainable. For example:
  * report = DeliveryMetricsAsyncReport(api_config, access_token, advertiser_id) \
@@ -70,8 +70,9 @@ export class DeliveryMetricsAsyncReport extends AdAnalyticsAttributes {
       'delivery_metrics', api_config, access_token, advertiser_id
     );
 
-    // level is a required attribute
+    // set required attributes
     this.required_attrs.add('level');
+    this.required_attrs.add('granularity');
 
     // This dictionary lists values for attributes that are enumerated
     // in the API documentation. The keys are the names of the attributes,
@@ -140,7 +141,7 @@ export class DeliveryMetricsAsyncReport extends AdAnalyticsAttributes {
 
   // Filters must be a list of structures with fields as specified by the API.
   filters(filters) {
-    this.attrs.filters = encodeURIComponent(JSON.stringify(filters));
+    this.attrs.filters = JSON.stringify(filters);
     return this;
   }
 
@@ -158,13 +159,14 @@ export class DeliveryMetricsAsyncReport extends AdAnalyticsAttributes {
   }
 
   // expose attributes for testing
-  post_uri_attributes() {
-    return this.uri_attributes('metrics', false);
+  post_data_attributes() {
+    // metrics are required
+    return this.data_attributes('columns', true);
   }
 
   // Pass attributes to AsyncReport.run().
   async run() {
-    await this.async_report.run(this.post_uri_attributes());
+    await this.async_report.run(this.post_data_attributes());
   }
 
   // Pass-through methods...

--- a/nodejs/src/v5/advertisers.js
+++ b/nodejs/src/v5/advertisers.js
@@ -52,9 +52,9 @@ export class Advertisers extends ApiObject {
   // Get the ads associated with an Ad Account, Campaign, and Ad Group.
   // https://developers.pinterest.com/docs/api/v5/#operation/ads/list
   async get_ads(ad_account_id, campaign_id, ad_group_id, query_parameters) {
-    let qp = Object.assign({}, query_parameters);
-    qp.campaign_ids = [campaign_id];
-    qp.ad_group_ids = [ad_group_id];
-    return this.get_iterator(`/v5/ad_accounts/${ad_account_id}/ads`, qp);
+    return this.get_iterator(`\
+/v5/ad_accounts/${ad_account_id}/ads\
+?campaign_ids=${campaign_id}&ad_group_ids=${ad_group_id}`,
+    query_parameters);
   }
 }

--- a/nodejs/src/v5/advertisers.js
+++ b/nodejs/src/v5/advertisers.js
@@ -52,9 +52,9 @@ export class Advertisers extends ApiObject {
   // Get the ads associated with an Ad Account, Campaign, and Ad Group.
   // https://developers.pinterest.com/docs/api/v5/#operation/ads/list
   async get_ads(ad_account_id, campaign_id, ad_group_id, query_parameters) {
-    return this.get_iterator(`\
-/v5/ad_accounts/${ad_account_id}/ads\
-?campaign_ids=${campaign_id}&ad_group_ids=${ad_group_id}`,
-    query_parameters);
+    let qp = Object.assign({}, query_parameters);
+    qp.campaign_ids = [campaign_id];
+    qp.ad_group_ids = [ad_group_id];
+    return this.get_iterator(`/v5/ad_accounts/${ad_account_id}/ads`, qp);
   }
 }

--- a/python/scripts/analytics_api_example.py
+++ b/python/scripts/analytics_api_example.py
@@ -160,6 +160,7 @@ def main(argv=[]):
         DeliveryMetricsAsyncReport(api_config, access_token, advertiser_id)
         .last_30_days()
         .level("PIN_PROMOTION")
+        .granularity("DAY")
         .metrics({"IMPRESSION_1", "CLICKTHROUGH_1"})
         .filters(
             [{"field": "PIN_PROMOTION_STATUS", "operator": "=", "value": "APPROVED"}]

--- a/python/src/analytics_attributes.py
+++ b/python/src/analytics_attributes.py
@@ -129,10 +129,9 @@ class AnalyticsAttributes:
         self._metrics.add(metric)
         return self
 
-    def metrics_string(self, required=True):
+    def metrics_array(self, required=True):
         """
-        Returns the metrics as a comma-separated string, suitable
-        for a GET or POST parameter.
+        Returns the metrics as a sorted array.
         """
         if not self._metrics:
             # raise an exception if metrics are required but not set
@@ -143,7 +142,14 @@ class AnalyticsAttributes:
         # set order is nondeterministic, so create a sorted list
         metrics_list = list(self._metrics)
         metrics_list.sort()  # sort makes error testing and debugging easier
-        return ",".join(metrics_list)
+        return metrics_list
+
+    def metrics_string(self, required=True):
+        """
+        Returns the metrics as a comma-separated string, suitable
+        for a GET or POST parameter.
+        """
+        return ",".join(self.metrics_array(required=required))
 
     def verify_attributes(self, metrics_required=False):
         # check the required start and end date attributes
@@ -183,6 +189,27 @@ class AnalyticsAttributes:
         attr_list.sort()  # sort makes error testing and debugging easier
         for attr in attr_list:
             attributes += f"&{attr}={self.attrs[attr]}"
+
+        return attributes
+
+    def data_attributes(self, metrics_parameter, metrics_required):
+        """
+        Provides the attributes as a dict to provide for the
+        POST that requests or initiates the report.
+        """
+        self.verify_attributes()
+
+        attributes = {
+            "start_date": self._start_date,
+            "end_date": self._end_date
+        }
+
+        metrics = self.metrics_array(required=metrics_required)
+        if metrics and len(metrics) > 0:
+            attributes[metrics_parameter] = metrics
+
+        # put other attributes into the dict
+        attributes.update(self.attrs)
 
         return attributes
 

--- a/python/src/v3/advertisers.py
+++ b/python/src/v3/advertisers.py
@@ -6,7 +6,7 @@ class Advertisers(ApiObject):
         super().__init__(api_config, access_token)
         self.user_id = user_id
 
-    # https://developers.pinterest.com/docs/redoc/#operation/ads_v3_get_advertisers_by_owner_user_id_handler_GET
+    # https://developers.pinterest.com/docs/redoc/adtech_ads_v4/#operation/get_advertisers_handler
     def get(self, query_parameters=None):
         """
         Get the advertisers shared with the specified user_id.
@@ -14,7 +14,7 @@ class Advertisers(ApiObject):
         to return advertisers which are shared with your account.
         """
         return self.get_iterator(
-            "/ads/v3/advertisers/"
+            "/ads/v4/advertisers/"
             + f"?owner_user_id={self.user_id}"
             + "&include_acl=true",
             query_parameters,
@@ -47,30 +47,33 @@ class Advertisers(ApiObject):
             summary = f"[{idx+1}] {cls.summary(element, kind)}"
             print(summary)
 
-    # https://developers.pinterest.com/docs/redoc/#operation/ads_v3_get_advertiser_campaigns_handler_GET
+    # https://developers.pinterest.com/docs/redoc/adtech_ads_v4/#operation/get_campaigns_handler
     def get_campaigns(self, ad_account_id, query_parameters=None):
         """
         Get the campaigns associated with an Ad Account.
         """
         return self.get_iterator(
-            f"/ads/v3/advertisers/{ad_account_id}/campaigns/", query_parameters
+            f"/ads/v4/advertisers/{ad_account_id}/campaigns", query_parameters
         )
 
-    # https://developers.pinterest.com/docs/redoc/#operation/ads_v3_get_campaign_ad_groups_handler_GET
-    def get_ad_groups(self, _ad_account_id, campaign_id, query_parameters=None):
+    # https://developers.pinterest.com/docs/redoc/adtech_ads_v4/#operation/get_ad_groups_handler
+    def get_ad_groups(self, ad_account_id, campaign_id, query_parameters=None):
         """
         Get the ad groups associated with a Campaign.
         """
         return self.get_iterator(
-            f"/ads/v3/campaigns/{campaign_id}/ad_groups/", query_parameters
+            f"/ads/v4/advertisers/{ad_account_id}/ad_groups?campaign_ids={campaign_id}",
+            query_parameters
         )
 
-    # https://developers.pinterest.com/docs/redoc/#operation/ads_v3_get_ad_group_pin_promotions_handler_GET
+    # https://developers.pinterest.com/docs/redoc/adtech_ads_v4/#operation/get_ads_handler
     # Note: Ads used to be called "promoted pins" or "pin promotions."
-    def get_ads(self, _ad_account_id, _campaign_id, ad_group_id, query_parameters=None):
+    def get_ads(self, ad_account_id, campaign_id, ad_group_id, query_parameters=None):
         """
         Get the ads associated with an Ad Group.
         """
         return self.get_iterator(
-            f"/ads/v3/ad_groups/{ad_group_id}/pin_promotions/", query_parameters
+            f"/ads/v4/advertisers/{ad_account_id}/ads"
+            f"?campaign_ids={campaign_id}&ad_group_ids={ad_group_id}",
+            query_parameters
         )

--- a/python/src/v3/async_report.py
+++ b/python/src/v3/async_report.py
@@ -7,7 +7,7 @@ class AsyncReport(ApiObject):
 
     Subclasses must override:
        self.kind_of = String, The kind of report. Example: 'delivery_metrics'
-       self.post_uri_attributes() = Method that generates the attributes for the POST.
+       self.post_data_attributes() = Method that generates the data for the POST.
     """  # noqa: E501 because the long URL is okay
 
     def __init__(self, api_config, access_token, advertiser_id):
@@ -24,27 +24,24 @@ class AsyncReport(ApiObject):
     def request_report(self):
         """
         For documentation, see:
-          https://developers.pinterest.com/docs/redoc/combined_reporting/#operation/ads_v3_create_advertiser_delivery_metrics_report_POST
+          https://developers.pinterest.com/docs/redoc/adtech_ads_v4/#operation/create_async_delivery_metrics_handler
         """
         if not self.kind_of:
             raise RuntimeError("subclass must override the kind_of report")
 
         # create path and set required attributes
-        path = (
-            f"/ads/v3/reports/async/{self.advertiser_id}/{self.kind_of}/"
-            + self.post_uri_attributes()
-        )
-        self.token = self.post_data(path)["token"]
+        path = f"/ads/v4/advertisers/{self.advertiser_id}/{self.kind_of}/async"
+        self.token = self.post_data(path, self.post_data_attributes())["token"]
 
     def poll_report(self):
         """
         For documentation, see:
-          https://developers.pinterest.com/docs/redoc/combined_reporting/#operation/ads_v3_get_advertiser_delivery_metrics_report_handler_GET
+          https://developers.pinterest.com/docs/redoc/adtech_ads_v4/#operation/get_async_delivery_metrics_handler
 
         Executes a single GET request to retrieve the status and (if available) the URL for the report.
         """  # noqa: E501 because the long URL is okay
         path = (
-            f"/ads/v3/reports/async/{self.advertiser_id}/{self.kind_of}/"
+            f"/ads/v4/advertisers/{self.advertiser_id}/{self.kind_of}/async"
             + f"?token={self.token}"
         )
         poll_data = self.request_data(path)


### PR DESCRIPTION
The /ads/v3 API has been decommissioned, so the API quickstart needs to use /ads/v4 instead of /ads/v3.

This pull request has all of the required changes, including code, tests, and internal documentation.
