### PR TITLE
TPP-1863: improve analytics documentation

### DIFF
--- a/nodejs/src/v3/analytics.js
+++ b/nodejs/src/v3/analytics.js
@@ -9,7 +9,7 @@ import { ApiObject } from '../api_object.js';
 
 /*
  * This class retrieves user (sometimes called "organic") metrics
- * using the v5 interface.
+ * using the v3 interface.
  *
  * The attribute functions are chainable. For example:
  *    Analytics(user_me_data['id'], api_config, access_token)

--- a/nodejs/src/v3/analytics.js
+++ b/nodejs/src/v3/analytics.js
@@ -147,6 +147,9 @@ export class AdAnalytics extends AdAnalyticsAttributes {
   }
 
   async request(request_uri) {
+    // Note that the uri_attributes method takes care of encoding the parameters.
+    // For example, the metrics are sent in the 'columns' parameter as a
+    // comma-delimited string.
     return await this.api_object.request_data(
       request_uri + this.uri_attributes('columns', true));
   }

--- a/nodejs/src/v3/analytics.js
+++ b/nodejs/src/v3/analytics.js
@@ -149,7 +149,7 @@ export class AdAnalytics extends AdAnalyticsAttributes {
   async request(request_uri) {
     // Note that the uri_attributes method takes care of encoding the parameters.
     // For example, the metrics are sent in the 'columns' parameter as a
-    // comma-delimited string.
+    // comma-separated string.
     return await this.api_object.request_data(
       request_uri + this.uri_attributes('columns', true));
   }

--- a/nodejs/src/v5/analytics.js
+++ b/nodejs/src/v5/analytics.js
@@ -108,7 +108,7 @@ ${this.uri_attributes('metric_types', false)}`);
  * are common to all advertising reports.
  *
  * Note that in v5, the metrics are provided to the API using the
- * 'columns' parameter, which is encoded as a comma-delimited string.
+ * 'columns' parameter, which is encoded as a comma-separated string.
  *
  * The ApiObject container implements the REST transaction used
  * to fetch the metrics.
@@ -127,7 +127,7 @@ export class AdAnalytics extends AdAnalyticsAttributes {
   async request(request_uri) {
     // Note that the uri_attributes method takes care of encoding the parameters.
     // For example, the metrics are sent in the 'columns' parameter as a
-    // comma-delimited string.
+    // comma-separated string.
     return await this.api_object.request_data(
       request_uri + this.uri_attributes('columns', true));
   }

--- a/nodejs/src/v5/analytics.js
+++ b/nodejs/src/v5/analytics.js
@@ -107,6 +107,9 @@ ${this.uri_attributes('metric_types', false)}`);
  * The AdAnalyticsAttributes parent class implements parameters that
  * are common to all advertising reports.
  *
+ * Note that in v5, the metrics are provided to the API using the
+ * 'columns' parameter, which is encoded as a comma-delimited string.
+ *
  * The ApiObject container implements the REST transaction used
  * to fetch the metrics.
  */
@@ -122,6 +125,9 @@ export class AdAnalytics extends AdAnalyticsAttributes {
   }
 
   async request(request_uri) {
+    // Note that the uri_attributes method takes care of encoding the parameters.
+    // For example, the metrics are sent in the 'columns' parameter as a
+    // comma-delimited string.
     return await this.api_object.request_data(
       request_uri + this.uri_attributes('columns', true));
   }

--- a/python/dev-requirements.txt
+++ b/python/dev-requirements.txt
@@ -4,6 +4,6 @@ nose~=1.3.7
 mock~=4.0.2
 rednose~=1.3.0
 requests-mock~=1.8.0
-black==20.8b1
+black==22.3.0
 flake8==3.8.4
 isort==5.6.4

--- a/python/src/v3/analytics.py
+++ b/python/src/v3/analytics.py
@@ -115,7 +115,7 @@ class AdAnalytics(AdAnalyticsAttributes, ApiObject):
         """
         Note that the uri_attributes method takes care of encoding the parameters.
         For example, the metrics are sent in the "columns" parameter as a
-        comma-delimited string.
+        comma-separated string.
         """
         return self.request_data(request_uri + self.uri_attributes("columns", True))
 

--- a/python/src/v3/analytics.py
+++ b/python/src/v3/analytics.py
@@ -11,7 +11,7 @@ from api_object import ApiObject
 class Analytics(AnalyticsAttributes, ApiObject):
     """
     This class retrieves user (sometimes called "organic") metrics
-    using the v4 interface.
+    using the v3 interface.
     """
 
     def __init__(self, user_id, api_config, access_token):

--- a/python/src/v3/analytics.py
+++ b/python/src/v3/analytics.py
@@ -11,7 +11,7 @@ from api_object import ApiObject
 class Analytics(AnalyticsAttributes, ApiObject):
     """
     This class retrieves user (sometimes called "organic") metrics
-    using the v5 interface.
+    using the v4 interface.
     """
 
     def __init__(self, user_id, api_config, access_token):
@@ -112,6 +112,11 @@ class AdAnalytics(AdAnalyticsAttributes, ApiObject):
         )
 
     def request(self, request_uri):
+        """
+        Note that the uri_attributes method takes care of encoding the parameters.
+        For example, the metrics are sent in the "columns" parameter as a
+        comma-delimited string.
+        """
         return self.request_data(request_uri + self.uri_attributes("columns", True))
 
     # https://developers.pinterest.com/docs/redoc/adtech_ads_v4/#operation/get_advertiser_delivery_metrics_handler

--- a/python/src/v5/analytics.py
+++ b/python/src/v5/analytics.py
@@ -19,7 +19,7 @@ class Analytics(AnalyticsAttributes, ApiObject):
        .metrics({"IMPRESSION", "PIN_CLICK_RATE"})
 
     Note that in v5, the metrics are provided to the API using the
-    "columns" parameter, which is encoded as a comma-delimited string.
+    "columns" parameter, which is encoded as a comma-separated string.
 
     The AnalyticsAttributes parent class implements parameters that
     are common to all analytics reports.
@@ -127,7 +127,7 @@ class AdAnalytics(AdAnalyticsAttributes, ApiObject):
         """
         Note that the uri_attributes method takes care of encoding the parameters.
         For example, the metrics are sent in the "columns" parameter as a
-        comma-delimited string.
+        comma-separated string.
         """
         return self.request_data(request_uri + self.uri_attributes("columns", True))
 

--- a/python/src/v5/analytics.py
+++ b/python/src/v5/analytics.py
@@ -18,6 +18,9 @@ class Analytics(AnalyticsAttributes, ApiObject):
        .last_30_days()
        .metrics({"IMPRESSION", "PIN_CLICK_RATE"})
 
+    Note that in v5, the metrics are provided to the API using the
+    "columns" parameter, which is encoded as a comma-delimited string.
+
     The AnalyticsAttributes parent class implements parameters that
     are common to all analytics reports.
 
@@ -121,6 +124,11 @@ class AdAnalytics(AdAnalyticsAttributes, ApiObject):
         )
 
     def request(self, request_uri):
+        """
+        Note that the uri_attributes method takes care of encoding the parameters.
+        For example, the metrics are sent in the "columns" parameter as a
+        comma-delimited string.
+        """
         return self.request_data(request_uri + self.uri_attributes("columns", True))
 
     # https://developers.pinterest.com/docs/api/v5/#operation/ad_account/analytics


### PR DESCRIPTION
1. Clarify that analytics metrics are requested with the "columns" parameter and encoded as a comma-delimited string.
2. Fix v3/v4 code comment to mention v4 instead of v5.
3. Fix broken github lint action by upgrading black.
