### PR TITLE
TPP-1854: update README documentation from ads_v3 to ads_v4

### DIFF
--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -413,7 +413,7 @@ optional arguments:
 ```
 
 ### [analytics_api_example.js](./scripts/analytics_api_example.js)
-Demonstrates how to use the API to generate an asynchronous delivery metrics report using the [request](https://developers.pinterest.com/docs/redoc/combined_reporting/#operation/ads_v3_create_advertiser_delivery_metrics_report_POST) and [get](https://developers.pinterest.com/docs/redoc/combined_reporting/#operation/ads_v3_get_advertiser_delivery_metrics_report_handler_GET) endpoints. This script only works for Pinterest API v3.
+Demonstrates how to use the API to generate an asynchronous delivery metrics report using the [create](https://developers.pinterest.com/docs/redoc/adtech_ads_v4/#operation/create_async_delivery_metrics_handler) and [get](https://developers.pinterest.com/docs/redoc/adtech_ads_v4/#operation/get_async_delivery_metrics_handler) endpoints. This script currently works only with Pinterest API v4, but we're working on supporting the same functionality in v5.
 
 <!--gen-->
 ```

--- a/python/README.md
+++ b/python/README.md
@@ -401,7 +401,7 @@ optional arguments:
 ```
 
 ### [analytics_api_example.py](./scripts/analytics_api_example.py)
- Demonstrates how to use the API to generate an asynchronous delivery metrics report using the [request](https://developers.pinterest.com/docs/redoc/combined_reporting/#operation/ads_v3_create_advertiser_delivery_metrics_report_POST) and [get](https://developers.pinterest.com/docs/redoc/combined_reporting/#operation/ads_v3_get_advertiser_delivery_metrics_report_handler_GET) endpoints. This script only works for Pinterest API v3.
+ Demonstrates how to use the API to generate an asynchronous delivery metrics report using the [create](https://developers.pinterest.com/docs/redoc/adtech_ads_v4/#operation/create_async_delivery_metrics_handler) and [get](https://developers.pinterest.com/docs/redoc/adtech_ads_v4/#operation/get_async_delivery_metrics_handler) endpoints. This script currently works only with Pinterest API v4, but we're working on supporting the same functionality in v5.
 
 <!--gen-->
 ```


### PR DESCRIPTION
Replace ads_v3 with ads_v4 links in README files.
