### PR TITLE
Use Pinterest-owned accounts for end-to-end tests

### DIFF
--- a/common/scripts/e2e_tests_ads
+++ b/common/scripts/e2e_tests_ads
@@ -37,9 +37,12 @@ OUTPUT_PREFIX=e2etest
 rm -f ${OUTPUT_PREFIX}_*.csv
 rm -f ${OUTPUT_PREFIX}_*.json
 
-# first refresh the tokens in case it has been a while since the tests were last run
+# Note: Pinterest ads test account tokens need to be recreated manually
+# once every 30 days. The following commands test to see whether the token
+# is valid.
 for VERSION in ${VERSIONS} ; do
-    ./scripts/refresh_access_token.${EXT} -a ${TEST3}_${VERSION} -${VERSION}
+    ./scripts/get_access_token.${EXT} -a ${TEST3}_${VERSION} -${VERSION}
+    ./scripts/get_access_token.${EXT} -a ${TEST4}_${VERSION} -${VERSION}
 done
 
 # get asynchronous analytics report
@@ -47,7 +50,7 @@ for VERSION in ${VERSIONS} ; do
     # python does not yet support v5...
     if [[ "${VERSION}" == "v3" || "${EXT}" == "js" ]] ; then
         DOCNAME=${OUTPUT_PREFIX}_${VERSION}_metrics_report.csv
-        printf "3\n${DOCNAME}\n" | \
+        printf "1\n${DOCNAME}\n" | \
             ./scripts/analytics_api_example.${EXT} -a ${TEST3}_${VERSION} -${VERSION}
         wc ${DOCNAME}
     fi
@@ -55,7 +58,7 @@ done
 
 # get all of the ads-related data for the test account
 for VERSION in ${VERSIONS} ; do
-    ./scripts/get_ads.${EXT} -a ${TEST3}_${VERSION} -${VERSION} --all-ads
+    ./scripts/get_ads.${EXT} -a ${TEST4}_${VERSION} -${VERSION} --all-ads
 done
 
 # get user analytics
@@ -68,14 +71,14 @@ done
 
 # get ad_account_user analytics (only available for v5)
 DOCNAME=${OUTPUT_PREFIX}_ad_account_user_analytics_v5.json
-printf "3\n${DOCNAME}\n" | \
+printf "1\n${DOCNAME}\n" | \
     ./scripts/get_analytics.${EXT} -a ${TEST3}_v5 -v5 -o ad_account_user
 wc ${DOCNAME}
 
 # get ad_account analytics
 for VERSION in ${VERSIONS} ; do
     DOCNAME=${OUTPUT_PREFIX}_ad_account_analytics_${VERSION}.json
-    printf "3\n${DOCNAME}\n" | \
+    printf "1\n${DOCNAME}\n" | \
          ./scripts/get_analytics.${EXT} -a ${TEST3}_${VERSION} -${VERSION} -o ad_account
     wc ${DOCNAME}
 done
@@ -83,24 +86,24 @@ done
 # get campaign analytics
 for VERSION in ${VERSIONS} ; do
     DOCNAME=${OUTPUT_PREFIX}_campaign_analytics_${VERSION}.json
-    printf "3\n2\n${DOCNAME}\n" | \
-         ./scripts/get_analytics.${EXT} -a ${TEST3}_${VERSION} -${VERSION} -o campaign
+    printf "${DOCNAME}\n" | \
+         ./scripts/get_analytics.${EXT} -a ${TEST3}_${VERSION} -${VERSION} -o campaign --ad-account-id ${TEST3_AD_ACCOUNT_ID} --campaign-id ${TEST3_CAMPAIGN_ID}
     wc ${DOCNAME}
 done
 
 # get ad group analytics
 for VERSION in ${VERSIONS} ; do
     DOCNAME=${OUTPUT_PREFIX}_ad_group_analytics_${VERSION}.json
-    printf "3\n2\n${DOCNAME}\n" | \
-         ./scripts/get_analytics.${EXT} -a ${TEST3}_${VERSION} -${VERSION} -o ad_group
+    printf "${DOCNAME}\n" | \
+         ./scripts/get_analytics.${EXT} -a ${TEST3}_${VERSION} -${VERSION} -o ad_group --ad-account-id ${TEST3_AD_ACCOUNT_ID} --campaign-id ${TEST3_CAMPAIGN_ID}
     wc ${DOCNAME}
 done
 
 # get ad analytics
 for VERSION in ${VERSIONS} ; do
     DOCNAME=${OUTPUT_PREFIX}_ad_analytics_${VERSION}.json
-    printf "3\n2\n${DOCNAME}\n" | \
-         ./scripts/get_analytics.${EXT} -a ${TEST3}_${VERSION} -${VERSION} -o ad
+    printf "${DOCNAME}\n" | \
+         ./scripts/get_analytics.${EXT} -a ${TEST3}_${VERSION} -${VERSION} -o ad --ad-account-id ${TEST3_AD_ACCOUNT_ID} --campaign-id ${TEST3_CAMPAIGN_ID}
     wc ${DOCNAME}
 done
 

--- a/common/scripts/e2e_tests_preamble
+++ b/common/scripts/e2e_tests_preamble
@@ -32,7 +32,11 @@ esac
 # Test accounts used by Pinterest to run the integration test.
 TEST1=pindexterp
 TEST2=penelopepintridge
-TEST3=dchaiken3407
+TEST3=322007579515566576
+TEST4=406450072528652334
+
+TEST3_AD_ACCOUNT_ID=549756064600
+TEST3_CAMPAIGN_ID=626744374247
 
 # Objects associated with the TEST1 account to be used in the integration tests.
 PIN=1097963584125248823

--- a/common/scripts/e2e_tests_prerequisites
+++ b/common/scripts/e2e_tests_prerequisites
@@ -46,17 +46,14 @@ if (! ./scripts/refresh_access_token.${EXT} -a ${TEST2}_v3 -v3) ; then
     ./scripts/get_access_token.${EXT} -a ${TEST2}_v3 -v3 -w -s read_pins,write_pins,read_boards,write_boards,read_users
 fi
 
-LOGIN_MESSAGE="Log into the ${TEST3} (ads test) account in your web browser and hit any key to continue..."
-if (! ./scripts/refresh_access_token.${EXT} -a ${TEST3}_v5 -v5) ; then
-    LOGIN_ACCOUNT=${TEST3}
-    read -s -n 1 -p "${LOGIN_MESSAGE}"
-    echo "authorizing v5 token for ${TEST3}"
-    ./scripts/get_access_token.${EXT} -a ${TEST3}_v5 -w -s ads:read,pins:read,boards:read,user_accounts:read
-fi
-if (! ./scripts/refresh_access_token.${EXT} -a ${TEST3}_v3 -v3) ; then
-    if [ "${LOGIN_ACCOUNT}" != "${TEST3}" ] ; then
-        read -s -n 1 -p "${LOGIN_MESSAGE}"
-    fi
-    echo "authorizing v3 token for ${TEST3}"
-    ./scripts/get_access_token.${EXT} -a ${TEST3}_v3 -v3 -w -s read_advertisers,read_campaigns,read_pin_promotions,read_pins,read_boards,read_users
-fi
+echo "Ensure that there is a valid v3 access token for the ${TEST3} (ads test) account"
+./scripts/get_access_token.${EXT} -a ${TEST3}_v3 -v3
+
+echo "Ensure that there is a valid v5 access token for the ${TEST3} (ads test) account"
+./scripts/get_access_token.${EXT} -a ${TEST3}_v5 -v5
+
+echo "Ensure that there is a valid v3 access token for the ${TEST4} (ads test) account"
+./scripts/get_access_token.${EXT} -a ${TEST4}_v3 -v3
+
+echo "Ensure that there is a valid v5 access token for the ${TEST4} (ads test) account"
+./scripts/get_access_token.${EXT} -a ${TEST4}_v5 -v5

--- a/common/scripts/e2e_tests_write
+++ b/common/scripts/e2e_tests_write
@@ -32,7 +32,10 @@ SCRIPT_DIR=$(cd $(dirname $0); pwd)
 #   copy the boards from the TEST1 account to the TEST2 account.
 #   Finally, read the boards and pins from the TEST2 account.
 for VERSION in ${VERSIONS} ; do
-    printf "Delete all boards for ${TEST2}\nyes\nyes\nyes\n" | \
+    # Note that the confirmation text in the following printf is not parameterized
+    # in order to avoid deleting all the boards from an account other than
+    # penelopepintridge.
+    printf "Delete all boards for penelopepintridge\nyes\nyes\nyes\n" | \
         ./scripts/delete_board.${EXT} -a ${TEST2}_${VERSION} -${VERSION} --all-boards
     ./scripts/copy_board.${EXT} -s ${TEST1}_${VERSION} -t ${TEST2}_${VERSION} -${VERSION} --all
     ./scripts/get_user_boards.${EXT} -a ${TEST2}_${VERSION} -${VERSION} --page-size 100

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -291,8 +291,7 @@ Demonstration of how to use the `POST /v5/pins` [endpoint](https://developers.pi
 ```
 $ ./scripts/copy_pin.js --help
 
-usage: copy_pin.js [-h] -p PIN_ID -b BOARD_ID [-m MEDIA] [-s SECTION] [-a ACCESS_TOKEN] [-l LOG_LEVEL]
-                   [-v API_VERSION]
+usage: copy_pin.js [-h] -p PIN_ID -b BOARD_ID [-m MEDIA] [-s SECTION] [-a ACCESS_TOKEN] [-l LOG_LEVEL] [-v API_VERSION]
 
 Copy A Pin
 
@@ -321,8 +320,8 @@ Demonstration of how to use the `POST /v3/boards` [endpoint](https://developers.
 ```
 $ ./scripts/copy_board.js --help
 
-usage: copy_board.js [-h] [-b BOARD_ID] [-n NAME] [-s SOURCE_ACCESS_TOKEN] [-t TARGET_ACCESS_TOKEN] [--all]
-                     [--dry-run] [-a ACCESS_TOKEN] [-l LOG_LEVEL] [-v API_VERSION]
+usage: copy_board.js [-h] [-b BOARD_ID] [-n NAME] [-s SOURCE_ACCESS_TOKEN] [-t TARGET_ACCESS_TOKEN] [--all] [--dry-run]
+                     [-a ACCESS_TOKEN] [-l LOG_LEVEL] [-v API_VERSION]
 
 Copy one Board or all Boards
 
@@ -374,7 +373,8 @@ Demonstrates how to use the API to retrieve analytics metrics with synchronous r
 ```
 $ ./scripts/get_analytics.js --help
 
-usage: get_analytics.js [-h] [-o {user,ad_account_user,ad_account,campaign,ad_group,ad}] [-a ACCESS_TOKEN]
+usage: get_analytics.js [-h] [-o {user,ad_account_user,ad_account,campaign,ad_group,ad}] [--ad-account-id AD_ACCOUNT_ID]
+                        [--campaign-id CAMPAIGN_ID] [--ad-group-id AD_GROUP_ID] [--ad-id AD_ID] [-a ACCESS_TOKEN]
                         [-l LOG_LEVEL] [-v API_VERSION]
 
 Get Analytics
@@ -383,6 +383,13 @@ optional arguments:
   -h, --help            show this help message and exit
   -o {user,ad_account_user,ad_account,campaign,ad_group,ad}, --analytics-object {user,ad_account_user,ad_account,campaign,ad_group,ad}
                         kind of object used to fetch analytics
+  --ad-account-id AD_ACCOUNT_ID
+                        Get analytics for this ad account identifier.
+  --campaign-id CAMPAIGN_ID
+                        Get analytics for this campaign identifier.
+  --ad-group-id AD_GROUP_ID
+                        Get analytics for this ad group identifier.
+  --ad-id AD_ID         Get analytics for this ad identifier.
   -a ACCESS_TOKEN, --access-token ACCESS_TOKEN
                         access token name
   -l LOG_LEVEL, --log-level LOG_LEVEL

--- a/python/README.md
+++ b/python/README.md
@@ -283,8 +283,7 @@ optional arguments:
 ```
 $ ./scripts/copy_pin.py --help
 
-usage: copy_pin.py [-h] -p PIN_ID [-m MEDIA] -b BOARD_ID [-s SECTION] [-a ACCESS_TOKEN] [-l LOG_LEVEL]
-                   [-v API_VERSION]
+usage: copy_pin.py [-h] -p PIN_ID [-m MEDIA] -b BOARD_ID [-s SECTION] [-a ACCESS_TOKEN] [-l LOG_LEVEL] [-v API_VERSION]
 
 Copy a Pin
 
@@ -312,8 +311,8 @@ optional arguments:
 ```
 $ ./scripts/copy_board.py --help
 
-usage: copy_board.py [-h] [-b BOARD_ID] [-n NAME] [-s SOURCE_ACCESS_TOKEN] [-t TARGET_ACCESS_TOKEN] [--all]
-                     [--dry-run] [-a ACCESS_TOKEN] [-l LOG_LEVEL] [-v API_VERSION]
+usage: copy_board.py [-h] [-b BOARD_ID] [-n NAME] [-s SOURCE_ACCESS_TOKEN] [-t TARGET_ACCESS_TOKEN] [--all] [--dry-run]
+                     [-a ACCESS_TOKEN] [-l LOG_LEVEL] [-v API_VERSION]
 
 Copy one Board or all Boards
 
@@ -363,7 +362,8 @@ optional arguments:
 ```
 $ ./scripts/get_analytics.py --help
 
-usage: get_analytics.py [-h] [-o {user,ad_account_user,ad_account,campaign,ad_group,ad}] [-a ACCESS_TOKEN]
+usage: get_analytics.py [-h] [-o {user,ad_account_user,ad_account,campaign,ad_group,ad}] [--ad-account-id AD_ACCOUNT_ID]
+                        [--campaign-id CAMPAIGN_ID] [--ad-group-id AD_GROUP_ID] [--ad-id AD_ID] [-a ACCESS_TOKEN]
                         [-l LOG_LEVEL] [-v API_VERSION]
 
 Get Analytics
@@ -372,6 +372,13 @@ optional arguments:
   -h, --help            show this help message and exit
   -o {user,ad_account_user,ad_account,campaign,ad_group,ad}, --analytics-object {user,ad_account_user,ad_account,campaign,ad_group,ad}
                         kind of object used to fetch analytics
+  --ad-account-id AD_ACCOUNT_ID
+                        Get analytics for this ad account identifier.
+  --campaign-id CAMPAIGN_ID
+                        Get analytics for this campaign identifier.
+  --ad-group-id AD_GROUP_ID
+                        Get analytics for this ad group identifier.
+  --ad-id AD_ID         Get analytics for this ad identifier.
   -a ACCESS_TOKEN, --access-token ACCESS_TOKEN
                         access token name
   -l LOG_LEVEL, --log-level LOG_LEVEL


### PR DESCRIPTION
* Uses Pinterest-owned instead of Pinterest-employee-owned user and ad accounts for end-to-end tests
* Implements some extra parameters for ad accounts with a large number of campaigns

Note: The end-to-end tests are provided mostly for transparency. It takes non-trivial effort to set up accounts that are compatible with the tests.
