### PR TITLE
e2e_tests: fix issue on linux

### DIFF
--- a/common/scripts/e2e_tests_ads
+++ b/common/scripts/e2e_tests_ads
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -ex
+#!/usr/bin/env bash
 #
 #
 # End-to-end (e2e) tests that read advertising objects and analytics data.

--- a/common/scripts/e2e_tests_preamble
+++ b/common/scripts/e2e_tests_preamble
@@ -12,6 +12,9 @@
 # in the same way that the api_app_credentials are factored out of api_env.
 #
 
+# exit on error, print all commands
+set -ex
+
 # check if the environment is set up for the quickstart
 if [ "$PINTEREST_APP_ID" == "" ] || [ "$PINTEREST_APP_SECRET" == "" ] ; then
    echo "This test requires the quickstart environment to be set."

--- a/common/scripts/e2e_tests_prerequisites
+++ b/common/scripts/e2e_tests_prerequisites
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -ex
+#!/usr/bin/env bash
 #
 # This script runs the commands in one of the programming language directories
 # using access tokens associated with test accounts on Pinterest. Run the

--- a/common/scripts/e2e_tests_read
+++ b/common/scripts/e2e_tests_read
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -ex
+#!/usr/bin/env bash
 #
 # This file runs the following scripts in the programming language directories
 # using access tokens associated with a test account on Pinterest:

--- a/common/scripts/e2e_tests_write
+++ b/common/scripts/e2e_tests_write
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash -ex
+#!/usr/bin/env bash
 #
 # NOTE: This script DELETES ALL OF THE BOARDS AND PINS for the second test
 # (TEST2) account, which is intended to be used only as a blank repository


### PR DESCRIPTION
```#/usr/bin/env bash -ex``` doesn't work as expected – at least, not on Ubuntu 18.04.6 LTS. Using ```#/usr/bin/env bash``` with ```set -ex``` works on both Linux and MacOS.
