### PR TITLE
nodejs: implement and test pin analytics

### DIFF
--- a/common/scripts/e2e_tests_ads
+++ b/common/scripts/e2e_tests_ads
@@ -31,8 +31,6 @@ SCRIPT_DIR=$(cd $(dirname $0); pwd)
 # source the common test script code
 . ${SCRIPT_DIR}/e2e_tests_preamble
 
-OUTPUT_PREFIX=e2etest
-
 # delete output files to avoid overwrite confirmations by scripts
 rm -f ${OUTPUT_PREFIX}_*.csv
 rm -f ${OUTPUT_PREFIX}_*.json

--- a/common/scripts/e2e_tests_preamble
+++ b/common/scripts/e2e_tests_preamble
@@ -54,3 +54,7 @@ VIDEO_FILE=${BASE_DIR}/test-media/test-video.mov
 
 # Versions to test. This variable should not need to change.
 VERSIONS="v3 v5"
+
+# Start the names of output files with this string so that they
+# are easy to remove at the end of tests.
+OUTPUT_PREFIX=e2etestout

--- a/common/scripts/e2e_tests_read
+++ b/common/scripts/e2e_tests_read
@@ -60,3 +60,14 @@ done
 for VERSION in ${VERSIONS} ; do
     ./scripts/get_user_boards.${EXT} -a ${TEST1}_${VERSION} -${VERSION}
 done
+
+# Pin analytics only work with v5. For now, only nodejs. Python is on the backlog.
+if [[ "${EXT}" == "js" ]] ; then
+    DOCNAME=${OUTPUT_PREFIX}_pin_analytics.json
+    printf "${DOCNAME}\n" | \
+        ./scripts/get_analytics.${EXT} -a ${TEST1}_v5 -v5 -o pin --pin-id ${PIN}
+    wc ${DOCNAME}
+fi
+
+# delete output files
+rm -f ${OUTPUT_PREFIX}_*.json

--- a/nodejs/scripts/get_analytics.js
+++ b/nodejs/scripts/get_analytics.js
@@ -159,7 +159,7 @@ async function main(argv) {
   }
 
   // Requesting pin analytics requires a pin_id.
-  if ((args.analytics_object === 'pin') && !args.pin_id) {
+  if (args.analytics_object === 'pin' && !args.pin_id) {
     console.log('Pin analytics require a pin identifier.');
     process.exit(1);
   }

--- a/nodejs/scripts/get_analytics.js
+++ b/nodejs/scripts/get_analytics.js
@@ -104,8 +104,11 @@ async function main(argv) {
   });
   parser.add_argument('-o', '--analytics-object', {
     default: 'user',
-    choices: ['user', 'ad_account_user', 'ad_account', 'campaign', 'ad_group', 'ad'],
+    choices: ['user', 'pin', 'ad_account_user', 'ad_account', 'campaign', 'ad_group', 'ad'],
     help: 'kind of object used to fetch analytics'
+  });
+  parser.add_argument('--pin-id', {
+    help: 'Get analytics for this pin identifier.'
   });
   parser.add_argument('--ad-account-id', {
     help: 'Get analytics for this ad account identifier.'
@@ -144,9 +147,22 @@ async function main(argv) {
   // imports that depend on the version of the API
   const { AccessToken } = await import(`../src/${api_config.version}/access_token.js`);
   const { Advertisers } = await import(`../src/${api_config.version}/advertisers.js`);
-  const { Analytics, AdAnalytics } = await import(`../src/${api_config.version}/analytics.js`);
+  const { UserAnalytics, PinAnalytics, AdAnalytics } = await import(`../src/${api_config.version}/analytics.js`);
   const { Scope } = await import(`../src/${api_config.version}/oauth_scope.js`);
   const { User } = await import(`../src/${api_config.version}/user.js`);
+
+  // This API edge case is best handled up right after API set-up...
+  if (api_config.version < 'v5' && args.analytics_object === 'pin') {
+    console.log('Pin analytics are supported by Pinterest API v5, but not v3 or v4.');
+    console.log('Try using -v5 or an analytics object besides pin.');
+    process.exit(1);
+  }
+
+  // Requesting pin analytics requires a pin_id.
+  if ((args.analytics_object === 'pin') && !args.pin_id) {
+    console.log('Pin analytics require a pin identifier.');
+    process.exit(1);
+  }
 
   // This API edge case is best handled up right after API set-up...
   if (api_config.version < 'v5' && args.analytics_object === 'ad_account_user') {
@@ -175,15 +191,23 @@ async function main(argv) {
   try {
     if (args.analytics_object === 'user') {
       // Get analytics for the user account associated with the access token.
-      const analytics = new Analytics(
+      const analytics = new UserAnalytics(
         user_me_data.id, api_config, access_token)
         .last_30_days()
         .metrics(['IMPRESSION', 'PIN_CLICK_RATE']);
 
       results = await analytics.get(null); // not calling with an ad_account_id argument
+    } else if (args.analytics_object === 'pin') {
+      // Get analytics for the pin.
+      const analytics = new PinAnalytics(
+        args.pin_id, api_config, access_token)
+        .last_30_days()
+        .metrics(['IMPRESSION', 'PIN_CLICK']);
+
+      results = await analytics.get(args.ad_account_id);
     } else if (args.analytics_object === 'ad_account_user') {
       // Get analytics for the user account associated with an ad account.
-      const analytics = new Analytics(
+      const analytics = new UserAnalytics(
         user_me_data.id, api_config, access_token)
         .last_30_days()
         .metrics(['IMPRESSION', 'PIN_CLICK_RATE']);

--- a/nodejs/src/v3/analytics.js
+++ b/nodejs/src/v3/analytics.js
@@ -118,7 +118,7 @@ ${this.uri_attributes('metric_types', false)}`);
  */
 export class PinAnalytics {
   constructor(_pin_id, _api_config, _access_token) {
-    throw new Error('Pin analytics are not supported in API v3. try v5 instead.');
+    throw new Error('Pin analytics are supported in API v5, but not v3 or v4.');
   }
 }
 

--- a/nodejs/src/v3/analytics.js
+++ b/nodejs/src/v3/analytics.js
@@ -3,16 +3,20 @@ import { ApiObject } from '../api_object.js';
 
 /**
  * This module uses Pinterest API v3 and v4 in two classes:
- * - Analytics synchronously retrieves user (organic) reports.
+ * - UserAnalytics synchronously retrieves user (organic) reports.
  * - AdAnalytics synchronously retrieves advertising reports.
+ *
+ * It also provides an implementation of the PinAnalytics class that
+ * just throws an error indicating that analytics for pins are only
+ * supported in API version 5.
  */
 
 /*
  * This class retrieves user (sometimes called "organic") metrics
- * using the v3 interface.
+ * for users with the v3 interface.
  *
  * The attribute functions are chainable. For example:
- *    Analytics(user_me_data['id'], api_config, access_token)
+ *    UserAnalytics(user_me_data['id'], api_config, access_token)
  *    .last_30_days()
  *    .metrics(['IMPRESSION', 'PIN_CLICK_RATE'])
  *
@@ -22,7 +26,7 @@ import { ApiObject } from '../api_object.js';
  * The ApiObject container implements the REST transaction used
  * to fetch the metrics.
  */
-export class Analytics extends AnalyticsAttributes {
+export class UserAnalytics extends AnalyticsAttributes {
   // https://developers.pinterest.com/docs/redoc/combined_reporting/#operation/v3_analytics_partner_metrics_GET
   constructor(user_id, api_config, access_token) {
     super();
@@ -105,6 +109,16 @@ export class Analytics extends AnalyticsAttributes {
     return await this.api_object.request_data(`\
 /v3/partners/analytics/users/${this.user_id}/metrics/?\
 ${this.uri_attributes('metric_types', false)}`);
+  }
+}
+
+/*
+ * This class throws an error that indicates that pin
+ * analytics are not supported in v3.
+ */
+export class PinAnalytics {
+  constructor(_pin_id, _api_config, _access_token) {
+    throw new Error('Pin analytics are not supported in API v3. try v5 instead.');
   }
 }
 

--- a/nodejs/src/v3/analytics.test.js
+++ b/nodejs/src/v3/analytics.test.js
@@ -1,4 +1,4 @@
-import { Analytics, AdAnalytics } from './analytics.js';
+import { UserAnalytics, PinAnalytics, AdAnalytics } from './analytics.js';
 import { ApiObject } from '../api_object.js';
 
 jest.mock('../api_object');
@@ -8,8 +8,8 @@ describe('v3 analytics tests', () => {
     jest.clearAllMocks();
   });
 
-  test('v3 analytics', async() => {
-    const analytics = new Analytics(
+  test('v3 user analytics', async() => {
+    const analytics = new UserAnalytics(
       'test_user_id', 'test_api_config', 'test_access_token')
       .start_date('2021-03-01')
       .end_date('2021-03-31')
@@ -62,6 +62,16 @@ start_date=2021-03-01&end_date=2021-03-31\
 &from_owned_content=1\
 &in_profile=0&include_curated=1&paid=2\
 &pin_format=standard&publish_types=all');
+  });
+
+  test('v3 pin analytics', async() => {
+    expect(() => {
+      /* eslint-disable no-unused-vars */
+      const analytics = new PinAnalytics(
+        'test_user_id', 'test_api_config', 'test_access_token');
+      /* eslint-enable no-unused-vars */
+    }).toThrowError(
+      new Error('Pin analytics are not supported in API v3. try v5 instead.'));
   });
 
   test('v4 ads analytics', async() => {

--- a/nodejs/src/v3/analytics.test.js
+++ b/nodejs/src/v3/analytics.test.js
@@ -71,7 +71,7 @@ start_date=2021-03-01&end_date=2021-03-31\
         'test_user_id', 'test_api_config', 'test_access_token');
       /* eslint-enable no-unused-vars */
     }).toThrowError(
-      new Error('Pin analytics are not supported in API v3. try v5 instead.'));
+      new Error('Pin analytics are supported in API v5, but not v3 or v4.'));
   });
 
   test('v4 ads analytics', async() => {

--- a/nodejs/src/v5/analytics.js
+++ b/nodejs/src/v5/analytics.js
@@ -2,8 +2,9 @@ import { AnalyticsAttributes, AdAnalyticsAttributes } from '../analytics_attribu
 import { ApiObject } from '../api_object.js';
 
 /**
- * This module uses Pinterest API v5 in two classes:
- * - Analytics synchronously retrieves user (organic) reports.
+ * This module uses Pinterest API v5 in three classes:
+ * - UserAnalytics synchronously retrieves user (organic) reports.
+ * - PinAnalytics synchronously retrieves pin (organic) reports.
  * - AdAnalytics synchronously retrieves advertising reports.
  */
 
@@ -12,7 +13,7 @@ import { ApiObject } from '../api_object.js';
  * using the v5 interface.
  *
  * The attribute functions are chainable. For example:
- *    Analytics(null, api_config, access_token)
+ *    UserAnalytics(null, api_config, access_token)
  *    .last_30_days()
  *    .metrics(['IMPRESSION', 'PIN_CLICK_RATE'])
  *
@@ -22,7 +23,7 @@ import { ApiObject } from '../api_object.js';
  * The ApiObject container implements the REST transaction used
  * to fetch the metrics.
  */
-export class Analytics extends AnalyticsAttributes {
+export class UserAnalytics extends AnalyticsAttributes {
   // https://developers.pinterest.com/docs/api/v5/#operation/user_account/analytics
   constructor(_user_id, api_config, access_token) {
     super();
@@ -87,6 +88,65 @@ export class Analytics extends AnalyticsAttributes {
     try {
       return await this.api_object.request_data(`\
 /v5/user_account/analytics?\
+${this.uri_attributes('metric_types', false)}`);
+    } finally {
+      delete this.attrs.ad_account_id;
+    }
+  }
+}
+
+/*
+ * This class retrieves pin (also "organic") metrics
+ * using the v5 interface.
+ *
+ * The attribute functions are chainable. For example:
+ *    PinAnalytics(null, api_config, access_token)
+ *    .last_30_days()
+ *    .metrics(['IMPRESSION', 'PIN_CLICK_RATE'])
+ *
+ * The AnalyticsAttributes parent class implements parameters that
+ * are common to all analytics reports.
+ *
+ * The ApiObject container implements the REST transaction used
+ * to fetch the metrics.
+ */
+export class PinAnalytics extends AnalyticsAttributes {
+  // https://developers.pinterest.com/docs/api/v5/#operation/pins/analytics
+  constructor(pin_id, api_config, access_token) {
+    super();
+    this.pin_id = pin_id;
+    this.api_object = new ApiObject(api_config, access_token);
+    Object.assign(this.enumerated_values, {
+      app_types: ['ALL', 'MOBILE', 'TABLET', 'WEB'],
+      split_field: [
+        'NO_SPLIT',
+        'APP_TYPE'
+      ]
+    });
+  }
+
+  // chainable attribute setters...
+
+  app_types(app_types) {
+    this.attrs.app_types = app_types;
+    return this;
+  }
+
+  split_field(split_field) {
+    this.attrs.split_field = split_field;
+    return this;
+  }
+
+  // Get analytics for the pin. If ad_account_id is set, get pin
+  // analytics associated with the specified Ad Account.
+  async get(ad_account_id) {
+    if (ad_account_id) {
+      this.attrs.ad_account_id = ad_account_id;
+    }
+
+    try {
+      return await this.api_object.request_data(`\
+/v5/pins/${this.pin_id}/analytics?\
 ${this.uri_attributes('metric_types', false)}`);
     } finally {
       delete this.attrs.ad_account_id;

--- a/nodejs/src/v5/analytics.js
+++ b/nodejs/src/v5/analytics.js
@@ -35,11 +35,8 @@ export class UserAnalytics extends AnalyticsAttributes {
       split_field: [
         'NO_SPLIT',
         'APP_TYPE',
-        'CONTENT_TYPE',
         'OWNED_CONTENT',
-        'SOURCE',
-        'PIN_FORMAT_CONVERSION_TYPE',
-        'ATTRIBUTION_EVENT'
+        'PIN_FORMAT'
       ]
     });
   }
@@ -62,19 +59,8 @@ export class UserAnalytics extends AnalyticsAttributes {
   }
 
   split_field(split_field) {
-    // The split_field attribute is not yet implemented in the Pinterest API.
-    // To work around this issue, use the appropriate filter attribute
-    // and send multiple requests. For example, instead of setting
-    // split_field to app_type, send three requests -- each with one of
-    // the possible app_types: mobile, tablet, and web.
-    throw new Error('split_field attribute not yet implemented in the Pinterest API');
-
-    // When the split_field attribute is implemented in the Pinterest API,
-    // remove the above comment and Error and uncomment the next two lines
-    // of code.
-
-    // this.attrs.split_field = split_field;
-    // return this;
+    this.attrs.split_field = split_field;
+    return this;
   }
 
   // Get analytics for the user account. If ad_account_id is set, get user

--- a/nodejs/src/v5/analytics.test.js
+++ b/nodejs/src/v5/analytics.test.js
@@ -36,13 +36,8 @@ start_date=2021-03-01&end_date=2021-03-31\
 &ad_account_id=test_ad_account\
 &from_claimed_content=Both&pin_format=regular');
 
-    analytics.app_types('web');
-
-    expect(() => {
-      analytics.split_field('SOURCE');
-    }).toThrowError(
-      new Error('split_field attribute not yet implemented in the Pinterest API')
-    );
+    // add a couple of fields
+    analytics.app_types('web').split_field('PIN_FORMAT');
 
     // verifies additional parameters and no ad_account_id
     expect(await analytics.get(null)).toEqual('test_response');
@@ -52,7 +47,8 @@ start_date=2021-03-01&end_date=2021-03-31\
 start_date=2021-03-01&end_date=2021-03-31\
 &metric_types=IMPRESSION,PIN_CLICK_RATE\
 &app_types=web\
-&from_claimed_content=Both&pin_format=regular');
+&from_claimed_content=Both&pin_format=regular\
+&split_field=PIN_FORMAT');
   });
 
   test('v5 pin analytics', async() => {

--- a/nodejs/src/v5/analytics.test.js
+++ b/nodejs/src/v5/analytics.test.js
@@ -1,4 +1,4 @@
-import { Analytics, AdAnalytics } from './analytics.js';
+import { UserAnalytics, PinAnalytics, AdAnalytics } from './analytics.js';
 import { ApiObject } from '../api_object.js';
 
 jest.mock('../api_object');
@@ -8,8 +8,8 @@ describe('v5 analytics tests', () => {
     jest.clearAllMocks();
   });
 
-  test('v5 analytics', async() => {
-    const analytics = new Analytics(
+  test('v5 user analytics', async() => {
+    const analytics = new UserAnalytics(
       'test_user_id', 'test_api_config', 'test_access_token')
       .start_date('2021-03-01')
       .end_date('2021-03-31')
@@ -53,6 +53,44 @@ start_date=2021-03-01&end_date=2021-03-31\
 &metric_types=IMPRESSION,PIN_CLICK_RATE\
 &app_types=web\
 &from_claimed_content=Both&pin_format=regular');
+  });
+
+  test('v5 pin analytics', async() => {
+    const analytics = new PinAnalytics(
+      'test_pin_id', 'test_api_config', 'test_access_token')
+      .start_date('2021-03-01')
+      .end_date('2021-03-31')
+      .metrics(['PIN_CLICK', 'IMPRESSION']);
+
+    expect(ApiObject.mock.instances.length).toBe(1);
+    expect(ApiObject.mock.calls[0]).toEqual(
+      ['test_api_config', 'test_access_token']);
+
+    const mock_request_data = jest.spyOn(ApiObject.prototype, 'request_data');
+    mock_request_data.mockResolvedValue('test_response');
+
+    expect(await analytics.get('test_ad_account'))
+      .toEqual('test_response');
+
+    // note that metrics should be sorted
+    expect(mock_request_data.mock.calls[0][0])
+      .toEqual('\
+/v5/pins/test_pin_id/analytics?\
+start_date=2021-03-01&end_date=2021-03-31\
+&metric_types=IMPRESSION,PIN_CLICK\
+&ad_account_id=test_ad_account');
+
+    analytics.app_types('WEB');
+    analytics.split_field('APP_TYPE');
+
+    // verifies additional parameters and no ad_account_id
+    expect(await analytics.get(null)).toEqual('test_response');
+    expect(mock_request_data.mock.calls[1][0])
+      .toEqual('\
+/v5/pins/test_pin_id/analytics?\
+start_date=2021-03-01&end_date=2021-03-31\
+&metric_types=IMPRESSION,PIN_CLICK\
+&app_types=WEB&split_field=APP_TYPE');
   });
 
   test('v5 ads analytics', async() => {


### PR DESCRIPTION
nodejs/javascript code now supports Pin analytics. This pull request has unit and e2e tests to cover the new functionality.

While I was modifying this code, I realized that I should check whether the split_field parameter for user analytics works. It does, so I removed the exception for the split_field parameter.