### PR TITLE
python: implement organic pin analytics

### DIFF
--- a/common/scripts/e2e_tests_read
+++ b/common/scripts/e2e_tests_read
@@ -62,12 +62,10 @@ for VERSION in ${VERSIONS} ; do
 done
 
 # Pin analytics only work with v5. For now, only nodejs. Python is on the backlog.
-if [[ "${EXT}" == "js" ]] ; then
-    DOCNAME=${OUTPUT_PREFIX}_pin_analytics.json
-    printf "${DOCNAME}\n" | \
-        ./scripts/get_analytics.${EXT} -a ${TEST1}_v5 -v5 -o pin --pin-id ${PIN}
-    wc ${DOCNAME}
-fi
+DOCNAME=${OUTPUT_PREFIX}_pin_analytics.json
+printf "${DOCNAME}\n" | \
+    ./scripts/get_analytics.${EXT} -a ${TEST1}_v5 -v5 -o pin --pin-id ${PIN}
+wc ${DOCNAME}
 
 # delete output files
 rm -f ${OUTPUT_PREFIX}_*.json

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -263,8 +263,8 @@ Retrieves all of the boards for a user with the `/v5/boards` [endpoint](https://
 ```
 $ ./scripts/get_user_boards.js --help
 
-usage: get_user_boards.js [-h] [-ps PAGE_SIZE] [--include-empty] [--no-include-empty] [--include-archived]
-                          [--no-include-archived] [-a ACCESS_TOKEN] [-l LOG_LEVEL] [-v API_VERSION]
+usage: get_user_boards.js [-h] [-ps PAGE_SIZE] [--include-empty] [--no-include-empty] [--include-archived] [--no-include-archived]
+                          [-a ACCESS_TOKEN] [-l LOG_LEVEL] [-v API_VERSION]
 
 Get A User's Boards
 
@@ -351,13 +351,21 @@ Reads information about advertiser accounts, campaigns, ad groups, and ads. By d
 ```
 $ ./scripts/get_ads.js --help
 
-usage: get_ads.js [-h] [--all-ads] [-a ACCESS_TOKEN] [-l LOG_LEVEL] [-v API_VERSION]
+usage: get_ads.js [-h] [--all-ads] [--ad-account-id AD_ACCOUNT_ID] [--campaign-id CAMPAIGN_ID] [--ad-group-id AD_GROUP_ID]
+                  [--ad-id AD_ID] [-a ACCESS_TOKEN] [-l LOG_LEVEL] [-v API_VERSION]
 
 Advertisers API Example
 
 optional arguments:
   -h, --help            show this help message and exit
   --all-ads             print all ads information
+  --ad-account-id AD_ACCOUNT_ID
+                        Get analytics for this ad account identifier.
+  --campaign-id CAMPAIGN_ID
+                        Get analytics for this campaign identifier.
+  --ad-group-id AD_GROUP_ID
+                        Get analytics for this ad group identifier.
+  --ad-id AD_ID         Get analytics for this ad identifier.
   -a ACCESS_TOKEN, --access-token ACCESS_TOKEN
                         access token name
   -l LOG_LEVEL, --log-level LOG_LEVEL
@@ -373,16 +381,17 @@ Demonstrates how to use the API to retrieve analytics metrics with synchronous r
 ```
 $ ./scripts/get_analytics.js --help
 
-usage: get_analytics.js [-h] [-o {user,ad_account_user,ad_account,campaign,ad_group,ad}] [--ad-account-id AD_ACCOUNT_ID]
-                        [--campaign-id CAMPAIGN_ID] [--ad-group-id AD_GROUP_ID] [--ad-id AD_ID] [-a ACCESS_TOKEN]
-                        [-l LOG_LEVEL] [-v API_VERSION]
+usage: get_analytics.js [-h] [-o {user,pin,ad_account_user,ad_account,campaign,ad_group,ad}] [--pin-id PIN_ID]
+                        [--ad-account-id AD_ACCOUNT_ID] [--campaign-id CAMPAIGN_ID] [--ad-group-id AD_GROUP_ID] [--ad-id AD_ID]
+                        [-a ACCESS_TOKEN] [-l LOG_LEVEL] [-v API_VERSION]
 
 Get Analytics
 
 optional arguments:
   -h, --help            show this help message and exit
-  -o {user,ad_account_user,ad_account,campaign,ad_group,ad}, --analytics-object {user,ad_account_user,ad_account,campaign,ad_group,ad}
+  -o {user,pin,ad_account_user,ad_account,campaign,ad_group,ad}, --analytics-object {user,pin,ad_account_user,ad_account,campaign,ad_group,ad}
                         kind of object used to fetch analytics
+  --pin-id PIN_ID       Get analytics for this pin identifier.
   --ad-account-id AD_ACCOUNT_ID
                         Get analytics for this ad account identifier.
   --campaign-id CAMPAIGN_ID

--- a/nodejs/src/v3/analytics.js
+++ b/nodejs/src/v3/analytics.js
@@ -13,7 +13,7 @@ import { ApiObject } from '../api_object.js';
 
 /*
  * This class retrieves user (sometimes called "organic") metrics
- * for users with the v3 interface.
+ * using the v3 interface.
  *
  * The attribute functions are chainable. For example:
  *    UserAnalytics(user_me_data['id'], api_config, access_token)

--- a/nodejs/src/v5/analytics.js
+++ b/nodejs/src/v5/analytics.js
@@ -86,9 +86,9 @@ ${this.uri_attributes('metric_types', false)}`);
  * using the v5 interface.
  *
  * The attribute functions are chainable. For example:
- *    PinAnalytics(null, api_config, access_token)
+ *    PinAnalytics(pin_id, api_config, access_token)
  *    .last_30_days()
- *    .metrics(['IMPRESSION', 'PIN_CLICK_RATE'])
+ *    .metrics(['IMPRESSION', 'PIN_CLICK'])
  *
  * The AnalyticsAttributes parent class implements parameters that
  * are common to all analytics reports.

--- a/nodejs/src/v5/analytics.test.js
+++ b/nodejs/src/v5/analytics.test.js
@@ -77,7 +77,7 @@ start_date=2021-03-01&end_date=2021-03-31\
 &ad_account_id=test_ad_account');
 
     analytics.app_types('WEB');
-    analytics.split_field('APP_TYPE');
+    analytics.split_field('NO_SPLIT');
 
     // verifies additional parameters and no ad_account_id
     expect(await analytics.get(null)).toEqual('test_response');
@@ -86,7 +86,7 @@ start_date=2021-03-01&end_date=2021-03-31\
 /v5/pins/test_pin_id/analytics?\
 start_date=2021-03-01&end_date=2021-03-31\
 &metric_types=IMPRESSION,PIN_CLICK\
-&app_types=WEB&split_field=APP_TYPE');
+&app_types=WEB&split_field=NO_SPLIT');
   });
 
   test('v5 ads analytics', async() => {

--- a/python/README.md
+++ b/python/README.md
@@ -256,8 +256,8 @@ optional arguments:
 ```
 $ ./scripts/get_user_boards.py --help
 
-usage: get_user_boards.py [-h] [-ps PAGE_SIZE] [--include-empty] [--no-include-empty] [--include-archived]
-                          [--no-include-archived] [-a ACCESS_TOKEN] [-l LOG_LEVEL] [-v API_VERSION]
+usage: get_user_boards.py [-h] [-ps PAGE_SIZE] [--include-empty] [--no-include-empty] [--include-archived] [--no-include-archived]
+                          [-a ACCESS_TOKEN] [-l LOG_LEVEL] [-v API_VERSION]
 
 Get A User's Boards
 
@@ -311,8 +311,8 @@ optional arguments:
 ```
 $ ./scripts/copy_board.py --help
 
-usage: copy_board.py [-h] [-b BOARD_ID] [-n NAME] [-s SOURCE_ACCESS_TOKEN] [-t TARGET_ACCESS_TOKEN] [--all] [--dry-run]
-                     [-a ACCESS_TOKEN] [-l LOG_LEVEL] [-v API_VERSION]
+usage: copy_board.py [-h] [-b BOARD_ID] [-n NAME] [-s SOURCE_ACCESS_TOKEN] [-t TARGET_ACCESS_TOKEN] [--all] [--dry-run] [-a ACCESS_TOKEN]
+                     [-l LOG_LEVEL] [-v API_VERSION]
 
 Copy one Board or all Boards
 
@@ -362,16 +362,17 @@ optional arguments:
 ```
 $ ./scripts/get_analytics.py --help
 
-usage: get_analytics.py [-h] [-o {user,ad_account_user,ad_account,campaign,ad_group,ad}] [--ad-account-id AD_ACCOUNT_ID]
-                        [--campaign-id CAMPAIGN_ID] [--ad-group-id AD_GROUP_ID] [--ad-id AD_ID] [-a ACCESS_TOKEN] [-l LOG_LEVEL]
-                        [-v API_VERSION]
+usage: get_analytics.py [-h] [-o {user,pin,ad_account_user,ad_account,campaign,ad_group,ad}] [--pin-id PIN_ID]
+                        [--ad-account-id AD_ACCOUNT_ID] [--campaign-id CAMPAIGN_ID] [--ad-group-id AD_GROUP_ID] [--ad-id AD_ID]
+                        [-a ACCESS_TOKEN] [-l LOG_LEVEL] [-v API_VERSION]
 
 Get Analytics
 
 optional arguments:
   -h, --help            show this help message and exit
-  -o {user,ad_account_user,ad_account,campaign,ad_group,ad}, --analytics-object {user,ad_account_user,ad_account,campaign,ad_group,ad}
+  -o {user,pin,ad_account_user,ad_account,campaign,ad_group,ad}, --analytics-object {user,pin,ad_account_user,ad_account,campaign,ad_group,ad}
                         kind of object used to fetch analytics
+  --pin-id PIN_ID       Get analytics for this pin identifier.
   --ad-account-id AD_ACCOUNT_ID
                         Get analytics for this ad account identifier.
   --campaign-id CAMPAIGN_ID

--- a/python/scripts/get_analytics.py
+++ b/python/scripts/get_analytics.py
@@ -74,8 +74,11 @@ def main(argv=[]):
         "-o",
         "--analytics-object",
         default="user",
-        choices=["user", "ad_account_user", "ad_account", "campaign", "ad_group", "ad"],
+        choices=["user", "pin", "ad_account_user", "ad_account", "campaign", "ad_group", "ad"],
         help="kind of object used to fetch analytics",
+    )
+    parser.add_argument(
+        "--pin-id", help="Get analytics for this pin identifier."
     )
     parser.add_argument(
         "--ad-account-id", help="Get analytics for this ad account identifier."
@@ -104,16 +107,27 @@ def main(argv=[]):
     api_config = ApiConfig(verbosity=args.log_level, version=args.api_version)
 
     # This API edge case is best handled up right after API set-up...
+    if api_config.version < "v5" and args.analytics_object == "pin":
+        print("Pin analytics for shared accounts are")
+        print("supported by Pinterest API v5, but not v3 or v4.")
+        print("Try using -v5 or an analytics object besides pin.")
+        exit(1)
+
     if api_config.version < "v5" and args.analytics_object == "ad_account_user":
         print("User account analytics for shared accounts are")
         print("supported by Pinterest API v5, but not v3 or v4.")
         print("Try using -v5 or an analytics object besides ad_account_user.")
         exit(1)
 
+    # Requesting pin analytics requires a pin_id.
+    if args.analytics_object == "pin" and not args.pin_id:
+        print("Pin analytics require a pin identifier.")
+        exit(1)
+
     # imports that depend on the version of the API
     from access_token import AccessToken
     from advertisers import Advertisers
-    from analytics import AdAnalytics, Analytics
+    from analytics import AdAnalytics, PinAnalytics, UserAnalytics
     from oauth_scope import Scope
     from user import User
 
@@ -136,15 +150,23 @@ def main(argv=[]):
     if args.analytics_object == "user":
         # Get analytics for the user account associated with the access token.
         analytics = (
-            Analytics(user_me_data.get("id"), api_config, access_token)
+            UserAnalytics(user_me_data.get("id"), api_config, access_token)
             .last_30_days()
             .metrics({"IMPRESSION", "PIN_CLICK_RATE"})
         )
         results = analytics.get()  # not calling with an ad_account_id argument
+    elif args.analytics_object == "pin":
+        # Get analytics for the pin.
+        analytics = (
+            PinAnalytics(args.pin_id, api_config, access_token)
+            .last_30_days()
+            .metrics({"IMPRESSION", "PIN_CLICK"})
+        )
+        results = analytics.get(args.account_id)  # account id may be None
     elif args.analytics_object == "ad_account_user":
         # Get analytics for the user account associated with an ad account.
         analytics = (
-            Analytics(user_me_data.get("id"), api_config, access_token)
+            UserAnalytics(user_me_data.get("id"), api_config, access_token)
             .last_30_days()
             .metrics({"IMPRESSION", "PIN_CLICK_RATE"})
         )

--- a/python/scripts/get_analytics.py
+++ b/python/scripts/get_analytics.py
@@ -74,12 +74,18 @@ def main(argv=[]):
         "-o",
         "--analytics-object",
         default="user",
-        choices=["user", "pin", "ad_account_user", "ad_account", "campaign", "ad_group", "ad"],
+        choices=[
+            "user",
+            "pin",
+            "ad_account_user",
+            "ad_account",
+            "campaign",
+            "ad_group",
+            "ad",
+        ],
         help="kind of object used to fetch analytics",
     )
-    parser.add_argument(
-        "--pin-id", help="Get analytics for this pin identifier."
-    )
+    parser.add_argument("--pin-id", help="Get analytics for this pin identifier.")
     parser.add_argument(
         "--ad-account-id", help="Get analytics for this ad account identifier."
     )

--- a/python/scripts/get_analytics.py
+++ b/python/scripts/get_analytics.py
@@ -162,7 +162,7 @@ def main(argv=[]):
             .last_30_days()
             .metrics({"IMPRESSION", "PIN_CLICK"})
         )
-        results = analytics.get(args.account_id)  # account id may be None
+        results = analytics.get(args.ad_account_id)  # ad account id may be None
     elif args.analytics_object == "ad_account_user":
         # Get analytics for the user account associated with an ad account.
         analytics = (

--- a/python/src/v3/analytics.py
+++ b/python/src/v3/analytics.py
@@ -99,6 +99,7 @@ class PinAnalytics(AnalyticsAttributes, ApiObject):
     This class throws an error that indicates that pin
     analytics are not supported in v3.
     """
+
     def __init__(self, _user_id, _api_config, _access_token):
         raise RuntimeError("Pin analytics are supported in API v5, but not v3 or v4.")
 

--- a/python/src/v3/analytics.py
+++ b/python/src/v3/analytics.py
@@ -94,12 +94,13 @@ class UserAnalytics(AnalyticsAttributes, ApiObject):
         return self
 
 
-class UserAnalytics(AnalyticsAttributes, ApiObject):
+class PinAnalytics(AnalyticsAttributes, ApiObject):
     """
     This class throws an error that indicates that pin
     analytics are not supported in v3.
     """
-    raise RuntimeError("Pin analytics are supported in API v5, but not v3 or v4.");
+    def __init__(self, _user_id, _api_config, _access_token):
+        raise RuntimeError("Pin analytics are supported in API v5, but not v3 or v4.")
 
 
 class AdAnalytics(AdAnalyticsAttributes, ApiObject):

--- a/python/src/v3/analytics.py
+++ b/python/src/v3/analytics.py
@@ -4,11 +4,14 @@ from api_object import ApiObject
 #
 # This module uses Pinterest API v3 and v4 in two classes:
 # * Analytics synchronously retrieves user (organic) reports.
-# * AdAnalytics synchronously retrieves advertising reports.
+# * UserAnalytics synchronously retrieves advertising reports.
 #
+# It also provides an implementation of the PinAnalytics class that
+# just throws an error indicating that analytics for pins are only
+# supported in API version 5.
 
 
-class Analytics(AnalyticsAttributes, ApiObject):
+class UserAnalytics(AnalyticsAttributes, ApiObject):
     """
     This class retrieves user (sometimes called "organic") metrics
     using the v3 interface.
@@ -89,6 +92,14 @@ class Analytics(AnalyticsAttributes, ApiObject):
     def include_curated(self, include_curated):
         self.attrs["include_curated"] = include_curated
         return self
+
+
+class UserAnalytics(AnalyticsAttributes, ApiObject):
+    """
+    This class throws an error that indicates that pin
+    analytics are not supported in v3.
+    """
+    raise RuntimeError("Pin analytics are supported in API v5, but not v3 or v4.");
 
 
 class AdAnalytics(AdAnalyticsAttributes, ApiObject):

--- a/python/src/v5/analytics.py
+++ b/python/src/v5/analytics.py
@@ -2,19 +2,20 @@ from analytics_attributes import AdAnalyticsAttributes, AnalyticsAttributes
 from api_object import ApiObject
 
 #
-# This module uses Pinterest API v5 in two classes:
-# * Analytics synchronously retrieves user (organic) reports.
+# This module uses Pinterest API v5 in three classes:
+# * UserAnalytics synchronously retrieves user (organic) reports.
+# * PinAnalytics synchronously retrieves pin (organic) reports.
 # * AdAnalytics synchronously retrieves advertising reports.
 #
 
 
-class Analytics(AnalyticsAttributes, ApiObject):
+class UserAnalytics(AnalyticsAttributes, ApiObject):
     """
     This class retrieves user (sometimes called "organic") metrics
     using the v5 interface.
 
     The attribute functions are chainable. For example:
-       Analytics(user_me_data.get("id"), api_config, access_token)
+       UserAnalytics(user_me_data.get("id"), api_config, access_token)
        .last_30_days()
        .metrics({"IMPRESSION", "PIN_CLICK_RATE"})
 
@@ -38,11 +39,8 @@ class Analytics(AnalyticsAttributes, ApiObject):
                 "split_field": {
                     "NO_SPLIT",
                     "APP_TYPE",
-                    "CONTENT_TYPE",
                     "OWNED_CONTENT",
-                    "SOURCE",
-                    "PIN_FORMAT_CONVERSION_TYPE",
-                    "ATTRIBUTION_EVENT",
+                    "PIN_FORMAT",
                 },
             }
         )
@@ -62,23 +60,8 @@ class Analytics(AnalyticsAttributes, ApiObject):
         return self
 
     def split_field(self, split_field):
-        """
-        The split_field attribute is not yet implemented in the Pinterest API.
-        To work around this issue, use the appropriate filter attribute
-        and send multiple requests. For example, instead of setting
-        split_field to app_type, send three requests -- each with one of
-        the possible app_types: mobile, tablet, and web.
-        """
-        raise AttributeError(
-            "split_field attribute not yet implemented in the Pinterest API"
-        )
-
-        # When the split_field attribute is implemented in the Pinterest API,
-        # remove the above comment and Error and uncomment the next two lines
-        # of code.
-
-        # self.attrs["split_field"] = split_field
-        # return self
+        self.attrs["split_field"] = split_field
+        return self
 
     # https://developers.pinterest.com/docs/api/v5/#operation/user_account/analytics
     def get(self, ad_account_id=None):
@@ -91,6 +74,65 @@ class Analytics(AnalyticsAttributes, ApiObject):
         try:
             return self.request_data(
                 "/v5/user_account/analytics?"
+                + self.uri_attributes("metric_types", False)
+            )
+        finally:
+            self.attrs.pop("ad_account_id", None)
+
+
+class PinAnalytics(AnalyticsAttributes, ApiObject):
+    """
+    This class retrieves pin (also "organic") metrics
+    using the v5 interface.
+
+    https://developers.pinterest.com/docs/api/v5/#operation/pins/analytics
+
+    The attribute functions are chainable. For example:
+       PinAnalytics(user_id, api_config, access_token)
+       .last_30_days()
+       .metrics({"IMPRESSION", "PIN_CLICK"})
+
+    The AnalyticsAttributes parent class implements parameters that
+    are common to all analytics reports.
+
+    The ApiObject parent class implements the REST transaction used
+    to fetch the metrics.
+    """
+
+    def __init__(self, pin_id, api_config, access_token):
+        super().__init__(api_config, access_token)
+        self.pin_id = pin_id
+        self.enumerated_values.update(
+            {
+                "app_types": {"all", "mobile", "tablet", "web"},
+                "split_field": {
+                    "NO_SPLIT",
+                    "APP_TYPE",
+                 },
+            }
+        )
+
+        # chainable attribute setters...
+
+    def app_types(self, app_types):
+        self.attrs["app_types"] = app_types
+        return self
+
+    def split_field(self, split_field):
+        self.attrs["split_field"] = split_field
+        return self
+
+    # https://developers.pinterest.com/docs/api/v5/#operation/user_account/analytics
+    def get(self, ad_account_id=None):
+        """
+        Get analytics for the pin. If ad_account_id is set, get pin
+        analytics associated with the specified Ad Account.
+        """
+        if ad_account_id:
+            self.attrs["ad_account_id"] = ad_account_id
+        try:
+            return self.request_data(
+                f"/v5/pins/{self.pin_id}/analytics?"
                 + self.uri_attributes("metric_types", False)
             )
         finally:

--- a/python/src/v5/analytics.py
+++ b/python/src/v5/analytics.py
@@ -108,7 +108,7 @@ class PinAnalytics(AnalyticsAttributes, ApiObject):
                 "split_field": {
                     "NO_SPLIT",
                     "APP_TYPE",
-                 },
+                },
             }
         )
 

--- a/python/tests/src/v3/test_analytics.py
+++ b/python/tests/src/v3/test_analytics.py
@@ -1,15 +1,15 @@
 import unittest
 from unittest import mock
 
-from v3.analytics import AdAnalytics, Analytics
+from v3.analytics import AdAnalytics, PinAnalytics, UserAnalytics
 
 
-class AnalyticsTest(unittest.TestCase):
+class UserAnalyticsTest(unittest.TestCase):
     @mock.patch("v3.analytics.ApiObject.request_data")
     @mock.patch("v3.analytics.ApiObject.__init__")
-    def test_analytics(self, mock_init, mock_request_data):
+    def test_user_analytics(self, mock_init, mock_request_data):
         analytics = (
-            Analytics("test_user_id", "test_api_config", "test_access_token")
+            UserAnalytics("test_user_id", "test_api_config", "test_access_token")
             .start_date("2021-03-01")
             .end_date("2021-03-31")
             .metrics({"TOTAL_CLICKTHROUGH", "SPEND_IN_DOLLAR"})
@@ -55,6 +55,15 @@ class AnalyticsTest(unittest.TestCase):
             ValueError, r"downstream: not_valid is not one of \[0, 1, 2\]"
         ):
             analytics.get()
+
+
+class PinAnalyticsTest(unittest.TestCase):
+    def test_user_analytics(self):
+        # verify that instantiating a PinAnalytics object throws an error
+        with self.assertRaisesRegex(
+            RuntimeError, "Pin analytics are supported in API v5, but not v3 or v4."
+        ):
+            PinAnalytics("test_pin_id", "test_api_config", "test_access_token")
 
 
 class AdAnalyticsTest(unittest.TestCase):

--- a/python/tests/src/v5/test_analytics.py
+++ b/python/tests/src/v5/test_analytics.py
@@ -1,15 +1,15 @@
 import unittest
 from unittest import mock
 
-from v5.analytics import AdAnalytics, Analytics
+from v5.analytics import AdAnalytics, PinAnalytics, UserAnalytics
 
 
-class AnalyticsTest(unittest.TestCase):
+class UserAnalyticsTest(unittest.TestCase):
     @mock.patch("v5.analytics.ApiObject.request_data")
     @mock.patch("v5.analytics.ApiObject.__init__")
-    def test_analytics(self, mock_init, mock_request_data):
+    def test_user_analytics(self, mock_init, mock_request_data):
         analytics = (
-            Analytics("test_user_id", "test_api_config", "test_access_token")
+            UserAnalytics("test_user_id", "test_api_config", "test_access_token")
             .start_date("2021-03-01")
             .end_date("2021-03-31")
             .metrics({"PIN_CLICK_RATE", "IMPRESSION"})
@@ -34,12 +34,7 @@ class AnalyticsTest(unittest.TestCase):
         mock_request_data.reset_mock()
 
         analytics.app_types("web")
-
-        with self.assertRaisesRegex(
-            AttributeError,
-            "split_field attribute not yet implemented in the Pinterest API",
-        ):
-            analytics.split_field("SOURCE")
+        analytics.split_field("PIN_FORMAT")
 
         # verifies additional parameters and no ad_account_id
         self.assertEqual("test_response", analytics.get())
@@ -49,6 +44,7 @@ class AnalyticsTest(unittest.TestCase):
             "&metric_types=IMPRESSION,PIN_CLICK_RATE"
             "&app_types=web"
             "&from_claimed_content=Both&pin_format=regular"
+            "&split_field=PIN_FORMAT"
         )
         mock_request_data.reset_mock()
         # testing with tablet app type
@@ -60,6 +56,7 @@ class AnalyticsTest(unittest.TestCase):
             "&metric_types=IMPRESSION,PIN_CLICK_RATE"
             "&app_types=tablet"
             "&from_claimed_content=Both&pin_format=regular"
+            "&split_field=PIN_FORMAT"
         )
         mock_request_data.reset_mock()
         # testing with mobile app type
@@ -71,6 +68,7 @@ class AnalyticsTest(unittest.TestCase):
             "&metric_types=IMPRESSION,PIN_CLICK_RATE"
             "&app_types=mobile"
             "&from_claimed_content=Both&pin_format=regular"
+            "&split_field=PIN_FORMAT"
         )
         mock_request_data.reset_mock()
         # testing with all app types
@@ -82,6 +80,82 @@ class AnalyticsTest(unittest.TestCase):
             "&metric_types=IMPRESSION,PIN_CLICK_RATE"
             "&app_types=all"
             "&from_claimed_content=Both&pin_format=regular"
+            "&split_field=PIN_FORMAT"
+        )
+        mock_request_data.reset_mock()
+
+
+class PinAnalyticsTest(unittest.TestCase):
+    @mock.patch("v5.analytics.ApiObject.request_data")
+    @mock.patch("v5.analytics.ApiObject.__init__")
+    def test_pin_analytics(self, mock_init, mock_request_data):
+        analytics = (
+            PinAnalytics("test_user_id", "test_api_config", "test_access_token")
+            .start_date("2021-03-01")
+            .end_date("2021-03-31")
+            .metrics({"PIN_CLICK", "IMPRESSION"})
+        )
+
+        mock_init.assert_called_once_with("test_api_config", "test_access_token")
+
+        mock_request_data.return_value = "test_response"
+        self.assertEqual(
+            "test_response", analytics.get(ad_account_id="test_ad_account")
+        )
+        # note that metrics should be sorted
+        mock_request_data.assert_called_once_with(
+            "/v5/pins/test_user_id/analytics?"
+            "start_date=2021-03-01&end_date=2021-03-31"
+            "&metric_types=IMPRESSION,PIN_CLICK"
+            "&ad_account_id=test_ad_account"
+        )
+        mock_request_data.reset_mock()
+
+        analytics.app_types("web")
+        analytics.split_field("NO_SPLIT")
+
+        # verifies additional parameters and no ad_account_id
+        self.assertEqual("test_response", analytics.get())
+        mock_request_data.assert_called_once_with(
+            "/v5/pins/test_user_id/analytics?"
+            "start_date=2021-03-01&end_date=2021-03-31"
+            "&metric_types=IMPRESSION,PIN_CLICK"
+            "&app_types=web"
+            "&split_field=NO_SPLIT"
+        )
+        mock_request_data.reset_mock()
+
+        # testing with tablet app type
+        analytics.app_types("tablet")
+        self.assertEqual("test_response", analytics.get())
+        mock_request_data.assert_called_once_with(
+            "/v5/pins/test_user_id/analytics?"
+            "start_date=2021-03-01&end_date=2021-03-31"
+            "&metric_types=IMPRESSION,PIN_CLICK"
+            "&app_types=tablet"
+            "&split_field=NO_SPLIT"
+        )
+        mock_request_data.reset_mock()
+        # testing with mobile app type
+        analytics.app_types("mobile")
+        self.assertEqual("test_response", analytics.get())
+        mock_request_data.assert_called_once_with(
+            "/v5/pins/test_user_id/analytics?"
+            "start_date=2021-03-01&end_date=2021-03-31"
+            "&metric_types=IMPRESSION,PIN_CLICK"
+            "&app_types=mobile"
+            "&split_field=NO_SPLIT"
+        )
+        mock_request_data.reset_mock()
+        # testing with all app types
+        analytics.app_types("all")
+        self.assertEqual("test_response", analytics.get())
+        mock_request_data.assert_called_once_with(
+            "/v5/pins/test_user_id/analytics?"
+            "start_date=2021-03-01&end_date=2021-03-31"
+            "&metric_types=IMPRESSION,PIN_CLICK"
+            "&app_types=all"
+            "&split_field=NO_SPLIT"
         )
         mock_request_data.reset_mock()
 


### PR DESCRIPTION
* python: implementation for organic pin analytics, along with unit tests and end-to-end (e2e) test
* nodejs: fixed some documentation issues and a test parameter issue
* python: remove split_field errors because split_field is now implemented in the API