### PR TITLE
TPP-2043: repair doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository has code that is intended to provide a quick start for working w
 
 1. Set up the environment with your credentials (app ID and secret). This configuration works with the code in all of the language-specific directories.
 
-   * Get an application ID and secret by hitting the "Connect app" button at [https://developers.pinterest.com/apps/](https://developers.pinterest.com/apps/). You may first need to follow the steps required to [request trial access](https://developers.pinterest.com/docs/api/v5/#section/Requesting-Trial-Access) to the Pinterest API. You can also find step-by-step instructions on the [Glitch-based tutorial](https://pinterest-oauth-tutorial.glitch.me/).
+   * Get an application ID and secret by hitting the "Connect app" button at [https://developers.pinterest.com/apps/](https://developers.pinterest.com/apps/). You may first need to follow the steps required to [request trial access](https://developers.pinterest.com/docs/getting-started/getting-access/) to the Pinterest API. You can also find step-by-step instructions on the [Glitch-based tutorial](https://pinterest-oauth-tutorial.glitch.me/).
    * Once your app is connected, hit the Manage button for the app on [https://developers.pinterest.com/apps/](https://developers.pinterest.com/apps/) to see your App id and App secret key. (Click the Show key button to see the App secret key.)
    * Put your App ID and App secret key in an environment script file.
      ```
@@ -47,7 +47,7 @@ This repository has code that is intended to provide a quick start for working w
 
 ## OAuth 2.0 Authorization
 
-Access to Pinterest APIs via User Authorization requires following a flow based on [OAuth 2.0](https://tools.ietf.org/html/rfc6749). To learn about how to use OAuth 2.0 with the Pinterest API, check out the [Glitch-based tutorial](https://pinterest-oauth-tutorial.glitch.me/). For details regarding OAuth, please refer to our [v5 developer docs](https://developers.pinterest.com/docs/api/v5/#tag/Authentication) or [v3 developer docs](https://developers.pinterest.com/docs/redoc/#section/User-Authorization). The code in this repo demonstrates how to initiate the flow by starting a browser, and then handling the OAuth redirect to the development machine (localhost). The browser is used to obtain an authorization code, and then the code invoked by the redirect exchanges the authorization code for an access token.
+Access to Pinterest APIs via User Authorization requires following a flow based on [OAuth 2.0](https://tools.ietf.org/html/rfc6749). To learn about how to use OAuth 2.0 with the Pinterest API, check out the [Glitch-based tutorial](https://pinterest-oauth-tutorial.glitch.me/). For details regarding OAuth, please refer to our [v5 developer docs](https://developers.pinterest.com/docs/getting-started/authentication/) or [v3 developer docs](https://developers.pinterest.com/docs/redoc/#section/User-Authorization). The code in this repo demonstrates how to initiate the flow by starting a browser, and then handling the OAuth redirect to the development machine (localhost). The browser is used to obtain an authorization code, and then the code invoked by the redirect exchanges the authorization code for an access token.
 
 An access token is used to authenticate most API calls. In general, access tokens are valid for relatively long periods of time, in order to avoid asking users to go through the OAuth flow too often. When an access token expires, it is possible to refresh the token -- a capability that the code in this repo also demonstrates.
 

--- a/bash/scripts/v5/get_access_token.sh
+++ b/bash/scripts/v5/get_access_token.sh
@@ -27,7 +27,7 @@ echo 'getting auth_code...'
 
 # Specify the scopes for the user to authorize via OAuth.
 # This example requests typical read-only authorization.
-# For more information, see: https://developers.pinterest.com/docs/api/v5/#tag/Authentication
+# For more information, see: https://developers.pinterest.com/docs/getting-started/authentication/
 SCOPE="user_accounts:read"
 
 # This call opens the browser with the oauth information in the URI.

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -98,7 +98,7 @@ Valid OAuth 2.0 scopes for Pinterest API version v5:
   user_accounts:read  Read access to user accounts
 
 For more information, see:
-  https://developers.pinterest.com/docs/api/v5/#tag/Scopes
+  https://developers.pinterest.com/docs/getting-started/scopes/
 ```
 
 Use `--scopes help` to get a list of all possible scopes for v3:

--- a/nodejs/src/v5/oauth_scope.js
+++ b/nodejs/src/v5/oauth_scope.js
@@ -1,7 +1,7 @@
 import Enum from 'enum';
 
 // Enumerate the valid OAuth scopes.
-// For details, see: https://developers.pinterest.com/docs/api/v5/#tag/Scopes
+// For details, see: https://developers.pinterest.com/docs/getting-started/scopes/
 export const Scope = new Enum({
   // scopes names that are compatible across different API versions
   READ_ADS: 'ads:read',
@@ -49,5 +49,5 @@ Valid OAuth 2.0 scopes for Pinterest API version v5:
   user_accounts:read  Read access to user accounts
 
 For more information, see:
-  https://developers.pinterest.com/docs/api/v5/#tag/Scopes`);
+  https://developers.pinterest.com/docs/getting-started/scopes/`);
 }

--- a/python/README.md
+++ b/python/README.md
@@ -97,7 +97,7 @@ Valid OAuth 2.0 scopes for Pinterest API version v5:
   user_accounts:read  Read access to user accounts
 
 For more information, see:
-  https://developers.pinterest.com/docs/api/v5/#tag/Scopes`
+  https://developers.pinterest.com/docs/getting-started/scopes/
 ```
 
 Use `--scopes help` to get a list of all possible scopes for v3:

--- a/python/src/user_auth.py
+++ b/python/src/user_auth.py
@@ -108,7 +108,7 @@ def get_auth_code(api_config, scopes=None, refreshable=True):
         """
         This flow will typically be interrupted by the developer if the
         OAuth did not work in the browser. For details, see the documentation:
-         https://developers.pinterest.com/docs/api/v5/#tag/Authentication
+         https://developers.pinterest.com/docs/getting-started/authentication/
          https://developers.pinterest.com/docs/redoc/#section/User-Authorization/Start-the-OAuth-flow-%28explicit-server-side%29
         """  # noqa: E501 because the long URL is okay
         sys.exit("\nSorry that the OAuth redirect didn't work out. :-/")

--- a/python/src/v5/access_token.py
+++ b/python/src/v5/access_token.py
@@ -13,7 +13,7 @@ class AccessToken(AccessTokenCommon):
         """
         Execute the OAuth 2.0 process for obtaining an access token.
         For more information, see IETF RFC 6749: https://tools.ietf.org/html/rfc6749
-        and https://developers.pinterest.com/docs/api/v5/#tag/oauth
+        and https://developers.pinterest.com/docs/getting-started/authentication/
 
         For v5, scopes are required and tokens must be refreshable.
         """

--- a/python/src/v5/oauth_scope.py
+++ b/python/src/v5/oauth_scope.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 
 # Enumerate the valid OAuth scopes.
-# For details, see: https://developers.pinterest.com/docs/api/v5/#tag/Scopes
+# For details, see: https://developers.pinterest.com/docs/getting-started/scopes/
 class Scope(Enum):
     READ_ADS = "ads:read"
     READ_BOARDS = "boards:read"
@@ -54,5 +54,5 @@ Valid OAuth 2.0 scopes for Pinterest API version v5:
   user_accounts:read  Read access to user accounts
 
 For more information, see:
-  https://developers.pinterest.com/docs/api/v5/#tag/Scopes`"""
+  https://developers.pinterest.com/docs/getting-started/scopes/"""
     )


### PR DESCRIPTION
developers.pinterest.com recently changed its link structure. This pull request fixes the links to developers.pinterest.com that need to be repaired.
