### PR TITLE
v5 support for GET delivery_metrics

### DIFF
--- a/nodejs/scripts/analytics_api_example.js
+++ b/nodejs/scripts/analytics_api_example.js
@@ -119,27 +119,19 @@ async function main(argv) {
     // Get the full list of all delivery metrics.
     // This call is not used much in day-to-day API code, but is a useful endpoint
     // for learning about the metrics.
-    try {
-      const delivery_metrics = new DeliveryMetrics(api_config, access_token);
-      const metrics = await delivery_metrics.get();
+    const delivery_metrics = new DeliveryMetrics(api_config, access_token);
+    const metrics = await delivery_metrics.get();
 
-      console.log('Here are a couple of interesting metrics...');
-      for (const metric of metrics) {
-        if (metric.name === 'CLICKTHROUGH_1' ||
-            metric.name === 'IMPRESSION_1') {
-          delivery_metrics.print(metric);
-        }
+    console.log('Here are a couple of interesting metrics...');
+    for (const metric of metrics) {
+      if (metric.name === 'CLICKTHROUGH_1' ||
+          metric.name === 'IMPRESSION_1') {
+        delivery_metrics.print(metric);
       }
-
-      // To print the long list of all metrics, uncomment the next line.
-      // delivery_metrics.print_all(metrics);
-    } catch (error) {
-      // This endpoint is not essential, and is not supported by all API versions.
-      // So, just print the error and move along.
-      console.log(error.message);
-    } finally {
-      api_config.verbosity = verbosity; // restore verbosity
     }
+
+    // To print the long list of all metrics, uncomment the next line.
+    // delivery_metrics.print_all(metrics);
 
     // Step 4: Configure the options for the report
     // For documentation on async reports, see:

--- a/nodejs/scripts/analytics_api_example.js
+++ b/nodejs/scripts/analytics_api_example.js
@@ -129,6 +129,7 @@ async function main(argv) {
         delivery_metrics.print(metric);
       }
     }
+    api_config.verbosity = verbosity; // restore verbosity
 
     // To print the long list of all metrics, uncomment the next line.
     // delivery_metrics.print_all(metrics);

--- a/nodejs/src/delivery_metrics.js
+++ b/nodejs/src/delivery_metrics.js
@@ -1,13 +1,30 @@
-/**
- * This module will provide access to delivery metrics when it becomes available.
- */
+import { ApiObject } from './api_object.js';
 
 // Use this class to get and to print all of the available
 // advertising delivery metrics.
-//   https://developers.pinterest.com/docs/api/v5/#operation/delivery_metrics/get
-export class DeliveryMetrics {
-  // The full list of all available delivery metrics will be available in v5 soon.
+export class DeliveryMetrics extends ApiObject {
+  // Get the full list of all available delivery metrics.
+  // This call is not used much in day-to-day API code, but is a useful endpoint
+  // for learning about the metrics.
+  // https://developers.pinterest.com/docs/api/v5/#operation/delivery_metrics/get
   async get() {
-    throw new Error('Metric definitions are not available in API version v5.');
+    return (await this.request_data('/v5/resources/delivery_metrics')).items;
+  }
+
+  summary(delivery_metric) {
+    return `${delivery_metric.name}: ${delivery_metric.definition}`;
+  }
+
+  // Print summary of a single metric.
+  print(delivery_metric) {
+    console.log(this.summary(delivery_metric));
+  }
+
+  // Print summary of data returned by get().
+  print_all(delivery_metrics) {
+    console.log('Available delivery metrics:');
+    for (const [idx, metric] of delivery_metrics.entries()) {
+      console.log(`[${idx + 1}] ${this.summary(metric)}`);
+    }
   }
 }

--- a/nodejs/src/delivery_metrics.test.js
+++ b/nodejs/src/delivery_metrics.test.js
@@ -1,4 +1,7 @@
+import { ApiObject } from './api_object.js';
 import { DeliveryMetrics } from './delivery_metrics.js';
+
+jest.mock('./api_object');
 
 describe('delivery_metrics tests', () => {
   afterEach(() => {
@@ -6,12 +9,27 @@ describe('delivery_metrics tests', () => {
   });
 
   test('delivery metrics', async() => {
-    const test_dm = new DeliveryMetrics();
+    const test_dm = new DeliveryMetrics('test_api_config', 'test_access_token');
+    expect(ApiObject.mock.instances.length).toBe(1);
+    expect(ApiObject.mock.calls[0]).toEqual(['test_api_config', 'test_access_token']);
 
-    await expect(async() => {
-      await test_dm.get();
-    }).rejects.toThrowError(
-      new Error('Metric definitions are not available in API version v5.')
-    );
+    const mock_request_data = jest.spyOn(ApiObject.prototype, 'request_data');
+    mock_request_data.mockResolvedValueOnce({
+      items: [
+        { name: 'metric1', definition: 'description 1' },
+        { name: 'metric2', definition: 'description 2' }
+      ]
+    });
+    const metrics = await test_dm.get();
+
+    expect(test_dm.summary(metrics[1])).toEqual('metric2: description 2');
+
+    console.log = jest.fn(); // test output
+    test_dm.print_all(metrics);
+    expect(console.log.mock.calls).toEqual([
+      ['Available delivery metrics:'],
+      ['[1] metric1: description 1'],
+      ['[2] metric2: description 2']
+    ]);
   });
 });

--- a/python/scripts/analytics_api_example.py
+++ b/python/scripts/analytics_api_example.py
@@ -119,26 +119,22 @@ def main(argv=[]):
     verbosity = api_config.verbosity
     api_config.verbosity = min(verbosity, 2)
 
-    try:
-        # Get the full list of all delivery metrics.
-        # This call is not used much in day-to-day API code, but is a useful endpoint
-        # for learning about the metrics.
-        delivery_metrics = DeliveryMetrics(api_config, access_token)
-        metrics = delivery_metrics.get()
+    # Get the full list of all delivery metrics.
+    # This call is not used much in day-to-day API code, but is a useful endpoint
+    # for learning about the metrics.
+    delivery_metrics = DeliveryMetrics(api_config, access_token)
+    metrics = delivery_metrics.get()
 
-        print("Here are a couple of interesting metrics...")
-        for metric in metrics:
-            if metric["name"] == "CLICKTHROUGH_1" or metric["name"] == "IMPRESSION_1":
-                delivery_metrics.print(metric)
+    print("Here are a couple of interesting metrics...")
+    for metric in metrics:
+        if metric["name"] == "CLICKTHROUGH_1" or metric["name"] == "IMPRESSION_1":
+            delivery_metrics.print(metric)
 
-        """
-        To print the long list of all metrics, uncomment the next line.
-        delivery_metrics.print_all(metrics)
-        """
-    except RuntimeError as error:
-        print(error)
-    finally:
-        api_config.verbosity = verbosity  # restore verbosity
+    """
+    To print the long list of all metrics, uncomment the next line.
+    delivery_metrics.print_all(metrics)
+    """
+    api_config.verbosity = verbosity  # restore verbosity
 
     """
     Step 4: Configure the options for the report

--- a/python/src/delivery_metrics.py
+++ b/python/src/delivery_metrics.py
@@ -1,14 +1,37 @@
-class DeliveryMetrics:
+from api_object import ApiObject
+
+
+class DeliveryMetrics(ApiObject):
     """
-    This module will provide access to delivery metrics when it becomes available.
-      https://developers.pinterest.com/docs/api/v5/#operation/delivery_metrics/get
+    Use this class to get and to print all of the available
+    advertising delivery metrics.
     """
 
     def __init__(self, api_config, access_token):
-        pass
+        super().__init__(api_config, access_token)
 
     def get(self):
         """
-        The full list of all available delivery metrics will be available in v5 soon.
+        https://developers.pinterest.com/docs/api/v5/#operation/delivery_metrics/get
+        Get the full list of all available delivery metrics.
+        This call is not used much in day-to-day API code, but is a useful endpoint
+        for learning about the metrics.
         """
-        raise RuntimeError("Metric definitions are not available in API version v5.")
+        return self.request_data("/v5/resources/delivery_metrics").get("items")
+
+    def summary(self, delivery_metric):
+        return f"{delivery_metric['name']}: {delivery_metric['definition']}"
+
+    def print(self, delivery_metric):
+        """
+        Print summary of a single metric.
+        """
+        print(self.summary(delivery_metric))
+
+    def print_all(self, delivery_metrics):
+        """
+        Print summary of data returned by get().
+        """
+        print("Available delivery metrics:")
+        for idx, metric in enumerate(delivery_metrics):
+            print(f"[{idx + 1}] " + self.summary(metric))

--- a/python/tests/scripts/test_analytics_api_example.py
+++ b/python/tests/scripts/test_analytics_api_example.py
@@ -57,6 +57,16 @@ class AnalyticsApiExampleTest(IntegrationMocks):
                 ]
             },
         )
+        # request from DeliveryMetrics.get
+        rm.get(
+            "https://api.pinterest.com/v5/resources/delivery_metrics",
+            json={
+                "items": [
+                    {"name": "metric1", "definition": "description 1"},
+                    {"name": "metric2", "definition": "description 2"},
+                ]
+            },
+        )
 
         # request from AsyncReport.poll_report
         rm.get(

--- a/python/tests/src/test_delivery_metrics.py
+++ b/python/tests/src/test_delivery_metrics.py
@@ -1,13 +1,35 @@
 import unittest
+from unittest import mock
+from unittest.mock import call
 
 from delivery_metrics import DeliveryMetrics
 
 
 class DeliveryMetricsTest(unittest.TestCase):
-    def test_delivery_metrics(self):
+    @mock.patch("builtins.print")
+    @mock.patch("user.ApiObject.request_data")
+    @mock.patch("delivery_metrics.ApiObject.__init__")
+    def test_delivery_metrics(
+        self, mock_api_object_init, mock_api_object_request_data, mock_print
+    ):
         test_dm = DeliveryMetrics("test_api_config", "test_access_token")
+        mock_api_object_init.assert_called_once_with(
+            "test_api_config", "test_access_token"
+        )
 
-        with self.assertRaisesRegex(
-            RuntimeError, "Metric definitions are not available in API version v5."
-        ):
-            test_dm.get()
+        mock_api_object_request_data.return_value = {
+            "items": [
+                {"name": "metric1", "definition": "description 1"},
+                {"name": "metric2", "definition": "description 2"},
+            ]
+        }
+        metrics = test_dm.get()
+        self.assertEqual(test_dm.summary(metrics[1]), "metric2: description 2")
+        test_dm.print_all(metrics)
+        mock_print.assert_has_calls(
+            [
+                call("Available delivery metrics:"),
+                call("[1] metric1: description 1"),
+                call("[2] metric2: description 2"),
+            ]
+        )


### PR DESCRIPTION
Adds support for GET /v5/resources/delivery_metrics, which was recently transitioned from beta to general availability.

Includes unit tests for the endpoint and passes end-to-end (e2e) tests.
