### PR TITLE
fix e2e tests and add eslint-formatter

### DIFF
--- a/nodejs/Makefile
+++ b/nodejs/Makefile
@@ -15,7 +15,7 @@ lint:
 	DEBUG=eslint:cli-engine yarn run eslint src scripts
 
 lint-fix:
-	yarn run eslint --fix src scripts
+	yarn run eslint --fix --format summary-chart src scripts
 
 # Run this command after changing the help text for a script,
 # so that the usage.md file is updated.

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -18,6 +18,7 @@
     "babel-jest": "^27.0.1",
     "eslint": "^7.31.0",
     "eslint-config-standard": "^16.0.3",
+    "eslint-formatter-summary-chart": "^0.3.0",
     "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-jest": "^24.4.0",
     "eslint-plugin-node": "^11.1.0",

--- a/nodejs/src/pin.js
+++ b/nodejs/src/pin.js
@@ -17,6 +17,7 @@ export class Pin extends ApiMediaObject {
   static print_summary(pin_data) {
     console.log('--- Pin Summary ---');
     console.log('Pin ID:', pin_data.id);
+    console.log('Title:', pin_data.title);
     console.log('Description:', pin_data.description);
     console.log('Link:', pin_data.link);
     console.log('Domain:', pin_data.domain);

--- a/python/src/pin.py
+++ b/python/src/pin.py
@@ -14,6 +14,7 @@ class Pin(ApiMediaObject):
     def print_summary(cls, pin_data):
         print("--- Pin Summary ---")
         print("Pin ID:", pin_data["id"])
+        print("Title:", pin_data["title"])
         print("Description:", pin_data["description"])
         print("Link:", pin_data["link"])
         print("Section ID:", pin_data["board_section_id"])


### PR DESCRIPTION
1. Due to changes in the API, it's now necessary to print the pin title for the integration/e2e (end-to-end) tests to pass.
2. When I originally put together the nodejs build/lint structure, I wanted to include eslint-formatter-summary-chart to show JavaScript lint results but there was a bug in the module. Now that my fix to the module is in the upstream, I'm including it in the build.
