### PR TITLE
support everlasting refresh

### DIFF
--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -128,13 +128,14 @@ Refreshes an access token stored by using `./scripts/get_access_token.js` with t
 ```
 $ ./scripts/refresh_access_token.js --help
 
-usage: refresh_access_token.js [-h] [-ct] [-a ACCESS_TOKEN] [-l LOG_LEVEL]
+usage: refresh_access_token.js [-h] [-ct] [-e] [-a ACCESS_TOKEN] [-l LOG_LEVEL]
 
 Refresh Pinterest OAuth token
 
 optional arguments:
   -h, --help            show this help message and exit
   -ct, --cleartext      print the token in clear text
+  -e, --everlasting     everlasting refresh token
   -a ACCESS_TOKEN, --access-token ACCESS_TOKEN
                         access token name
   -l LOG_LEVEL, --log-level LOG_LEVEL

--- a/nodejs/scripts/refresh_access_token.js
+++ b/nodejs/scripts/refresh_access_token.js
@@ -13,6 +13,7 @@ import { common_arguments } from '../src/arguments.js';
 async function main(argv) {
   const parser = new ArgumentParser({ description: 'Refresh Pinterest OAuth token' });
   parser.add_argument('-ct', '--cleartext', { action: 'store_true', help: 'print the token in clear text' });
+  parser.add_argument('-e', '--everlasting', { action: 'store_true', help: 'everlasting refresh token' });
   common_arguments(parser);
   const args = parser.parse_args(argv);
 
@@ -21,7 +22,7 @@ async function main(argv) {
 
   const access_token = new AccessToken(api_config, { name: args.access_token });
   access_token.read();
-  await access_token.refresh();
+  await access_token.refresh({ everlasting: args.everlasting });
 
   // Note: It is best practice not to print credentials in clear text.
   // Pinterest engineers asked for this capability to make it easier to support partners.
@@ -30,6 +31,7 @@ async function main(argv) {
     console.log('clear text access token after refresh:', access_token.access_token);
   }
   console.log('hashed access token after refresh:', access_token.hashed());
+  console.log('hashed refresh token after refresh:', access_token.hashed_refresh_token());
 
   console.log('writing access token');
   access_token.write();

--- a/nodejs/scripts/refresh_example.js
+++ b/nodejs/scripts/refresh_example.js
@@ -49,7 +49,7 @@ async function main(argv) {
   // refresh the access_token
   // Note that the AccessToken encapsulates the credentials,
   // so there is no need to refresh the User or other objects.
-  await access_token.refresh();
+  await access_token.refresh({});
   hashed = access_token.hashed();
   if (access_token_hashes.has(hashed)) {
     console.log('Access Token is the same after refresh.');
@@ -60,6 +60,7 @@ async function main(argv) {
   // This call demonstrates that the access_token has changed
   // without printing the actual token.
   console.log('hashed access token:', hashed);
+  console.log('hashed refresh token:', access_token.hashed_refresh_token());
 
   console.log('accessing with refreshed access_token...');
   user_data = await user.get();
@@ -72,11 +73,12 @@ async function main(argv) {
   await new Promise(resolve => setTimeout(resolve, 1000));
 
   // refresh the access_token again
-  await access_token.refresh();
+  await access_token.refresh({});
 
   // Verify that the access_token has changed again.
   hashed = access_token.hashed();
   console.log('hashed access token:', hashed);
+  console.log('hashed refresh token:', access_token.hashed_refresh_token());
   if (access_token_hashes.has(hashed)) {
     console.log('Access Token is repeated after the second refresh.');
     process.exit(2);

--- a/nodejs/src/access_token.js
+++ b/nodejs/src/access_token.js
@@ -186,7 +186,7 @@ export class AccessToken extends ApiCommon {
     }
   }
 
-  async refresh() {
+  async refresh({ everlasting = false }) {
     // There should be a refresh_token, but it is best to check.
     if (!this.refresh_token) {
       throw new Error('AccessToken does not have a refresh token');
@@ -199,6 +199,9 @@ export class AccessToken extends ApiCommon {
         grant_type: 'refresh_token',
         refresh_token: this.refresh_token
       };
+      if (everlasting) {
+        post_data.refresh_on = true;
+      }
       if (this.api_config.verbosity >= 2) {
         console.log('POST', `${this.api_uri}/v5/oauth/token`);
         if (this.api_config.verbosity >= 3) {
@@ -213,6 +216,10 @@ export class AccessToken extends ApiCommon {
       });
       this.print_response(response);
       this.access_token = response.body.access_token;
+      if (response.body.refresh_token) {
+        console.log('received refresh token');
+        this.refresh_token = response.body.refresh_token;
+      }
     } catch (error) {
       this.print_and_throw_error(error);
     }

--- a/python/README.md
+++ b/python/README.md
@@ -125,13 +125,14 @@ options:
 ```
 $ ./scripts/refresh_access_token.py --help
 
-usage: refresh_access_token.py [-h] [-ct] [-a ACCESS_TOKEN] [-l LOG_LEVEL]
+usage: refresh_access_token.py [-h] [-ct] [-e] [-a ACCESS_TOKEN] [-l LOG_LEVEL]
 
 Refresh Pinterest OAuth token
 
 options:
   -h, --help            show this help message and exit
   -ct, --cleartext      print the token in clear text
+  -e, --everlasting     everlasting refresh token
   -a ACCESS_TOKEN, --access-token ACCESS_TOKEN
                         access token name
   -l LOG_LEVEL, --log-level LOG_LEVEL

--- a/python/scripts/refresh_access_token.py
+++ b/python/scripts/refresh_access_token.py
@@ -21,6 +21,9 @@ def main(argv=[]):
     parser.add_argument(
         "-ct", "--cleartext", action="store_true", help="print the token in clear text"
     )
+    parser.add_argument(
+        "-e", "--everlasting", action="store_true", help="everlasting refresh token"
+    )
     common_arguments(parser)
     args = parser.parse_args(argv)
 
@@ -29,7 +32,7 @@ def main(argv=[]):
 
     access_token = AccessToken(api_config, name=args.access_token)
     access_token.read()
-    access_token.refresh()
+    access_token.refresh(everlasting=args.everlasting)
 
     # Note: It is best practice not to print credentials in clear text.
     # Pinterest engineers asked for this capability to make it easier
@@ -38,6 +41,7 @@ def main(argv=[]):
         print("Please keep clear text tokens secure!")
         print("clear text access token after refresh: " + access_token.access_token)
     print("hashed access token after refresh: " + access_token.hashed())
+    print("hashed refresh token after refresh: " + access_token.hashed_refresh_token())
 
     # Use the access token to get information about the user. The purpose of this
     # call is to verify that the access token is working.

--- a/python/src/access_token.py
+++ b/python/src/access_token.py
@@ -173,9 +173,11 @@ class AccessToken(ApiCommon):
         self.refresh_token = unpacked["refresh_token"]
         self.scopes = unpacked["scope"]
 
-    def refresh(self):
+    def refresh(self, everlasting=False):
         print(f"refreshing {self.name}...")
         post_data = {"grant_type": "refresh_token", "refresh_token": self.refresh_token}
+        if everlasting:  # PINDP-2680: refresh_on=false does not work
+            post_data["refresh_on"] = True
         if self.api_config.verbosity >= 2:
             print("POST", self.api_config.api_uri + "/v5/oauth/token")
             if self.api_config.verbosity >= 3:
@@ -188,3 +190,6 @@ class AccessToken(ApiCommon):
         )
         unpacked = self.unpack(response)
         self.access_token = unpacked["access_token"]
+        # save refresh token if it was also refreshed
+        if "refresh_token" in unpacked:
+            self.refresh_token = unpacked["refresh_token"]


### PR DESCRIPTION
1. add command line arguments and parameters that send the `refresh_on` parameter when refreshing an access token
2. save the new `refresh_token` when returned by the API
3. add or modify unit tests that verify the old and new refresh functionality
