### PR TITLE
update more info link

### DIFF
--- a/nodejs/src/oauth_scope.js
+++ b/nodejs/src/oauth_scope.js
@@ -1,7 +1,7 @@
 import Enum from 'enum';
 
 // Enumerate the valid OAuth scopes.
-// For details, see: https://developers.pinterest.com/docs/getting-started/scopes/
+// For details, see: https://developers.pinterest.com/docs/getting-started/authentication-and-scopes/#pinterest-scopes
 export const Scope = new Enum({
   // scopes names that are compatible across different API versions
   READ_ADS: 'ads:read',
@@ -56,5 +56,5 @@ Valid OAuth 2.0 scopes for Pinterest API version v5:
   user_accounts:read  Read access to user accounts
 
 For more information, see:
-  https://developers.pinterest.com/docs/getting-started/scopes/`);
+  https://developers.pinterest.com/docs/getting-started/authentication-and-scopes/#pinterest-scopes`);
 }


### PR DESCRIPTION
Updated the "more information" link from ".../getting-started/scopes/" (redirected to different page) to the most recent URI, appending anchor so page opens at section. Done to save anyone pasting the link from the stdout into the browser time.