### PR TITLE
support OAuth with client credentials

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v2
         with:
-          node-version: 15.8
+          node-version: 18.17
       - name: Install dependencies
         run: npm install
       - name: Lint

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -57,7 +57,7 @@ Quick start code that demonstrates the OAuth 2.0 flow and tests the authenticati
 ```
 $ ./scripts/get_access_token.js --help
 
-usage: get_access_token.js [-h] [-w] [-ct] [-s SCOPES] [-a ACCESS_TOKEN]
+usage: get_access_token.js [-h] [-w] [-ct] [-s SCOPES] [-c] [-a ACCESS_TOKEN]
                            [-l LOG_LEVEL]
 
 Get Pinterest OAuth token
@@ -68,6 +68,8 @@ optional arguments:
   -ct, --cleartext      print the token in clear text
   -s SCOPES, --scopes SCOPES
                         comma separated list of scopes or "help"
+  -c, --client_credentials
+                        use client credentials
   -a ACCESS_TOKEN, --access-token ACCESS_TOKEN
                         access token name
   -l LOG_LEVEL, --log-level LOG_LEVEL

--- a/nodejs/scripts/copy_board.js
+++ b/nodejs/scripts/copy_board.js
@@ -155,9 +155,8 @@ async function main(argv) {
   let source_board;
   if (args.all_boards) { // copy all boards for the source user
     const user = new User(api_config, source_token);
-    const user_data = await user.get();
     source_board = new Board(null, api_config, source_token); // board_id set in loop below
-    boards = await user.get_boards(user_data, {});
+    boards = await user.get_boards({});
   } else { // copy just the board designated by board_id
     source_board = new Board(args.board_id, api_config, source_token);
     const source_board_data = await source_board.get();

--- a/nodejs/scripts/delete_board.js
+++ b/nodejs/scripts/delete_board.js
@@ -44,7 +44,7 @@ async function main(argv) {
   if (args.all_boards) { // delete all boards for the user
     const user = new User(api_config, access_token);
     const user_data = await user.get();
-    boards = await user.get_boards(user_data, {});
+    boards = await user.get_boards({});
     confirmation = `Delete all boards for ${user_data.username}`;
   } else { // copy just the board designated by board_id
     const deletion_board = new Board(args.board_id, api_config, access_token);

--- a/nodejs/scripts/get_access_token.js
+++ b/nodejs/scripts/get_access_token.js
@@ -30,13 +30,17 @@ import { Scope, print_scopes } from '../src/oauth_scope.js';
  *    OAuth scopes, allows experimentation with different sets of scopes. Specifying scopes prevents
  *    the access token from being read from the environment or file system, and forces the use of
  *    the browser-based OAuth process.
+ *  -c / --client-credentials:
+ *    This option is used to request an access token for the user account
+ *    associated with the PINTEREST_APP_ID. Use this option to avoid the need
+ *    to do the manual part of the OAuth process with at web browser.
  */
 async function main(argv) {
   const parser = new ArgumentParser({ description: 'Get Pinterest OAuth token' });
   parser.add_argument('-w', '--write', { action: 'store_true', help: 'write access token to file' });
   parser.add_argument('-ct', '--cleartext', { action: 'store_true', help: 'print the token in clear text' });
   parser.add_argument('-s', '--scopes', { help: 'comma separated list of scopes or "help"' });
-  parser.add_argument('-c', '--client_credentials', { action: 'store_true', help: 'use client credentials' });
+  parser.add_argument('-c', '--client_credentials', { action: 'store_true', help: 'access the application user account' });
   common_arguments(parser);
   const args = parser.parse_args(argv);
 

--- a/nodejs/scripts/get_access_token.js
+++ b/nodejs/scripts/get_access_token.js
@@ -36,6 +36,7 @@ async function main(argv) {
   parser.add_argument('-w', '--write', { action: 'store_true', help: 'write access token to file' });
   parser.add_argument('-ct', '--cleartext', { action: 'store_true', help: 'print the token in clear text' });
   parser.add_argument('-s', '--scopes', { help: 'comma separated list of scopes or "help"' });
+  parser.add_argument('-c', '--client_credentials', { action: 'store_true', help: 'use client credentials' });
   common_arguments(parser);
   const args = parser.parse_args(argv);
 
@@ -61,12 +62,12 @@ async function main(argv) {
       print_scopes();
       process.exit(1);
     });
-    await access_token.oauth({ scopes: scopes });
+    await access_token.oauth({ scopes, client_credentials: args.client_credentials });
   } else {
     // Try the different methods for getting an access token: from the environment,
     // from a file, and from Pinterest via the browser.
     try {
-      await access_token.fetch({});
+      await access_token.fetch({ client_credentials: args.client_credentials });
     } catch (error) { // probably because scopes are required
       parser.error(error);
     }
@@ -94,10 +95,13 @@ async function main(argv) {
     access_token.write();
   }
 
-  // use the access token to get information about the user
-  const user = new User(api_config, access_token);
-  const user_data = await user.get();
-  user.print_summary(user_data);
+  // Remove this conditional when GET /v5/user_account works with client credentials
+  if (!args.client_credentials) {
+    // use the access token to get information about the user
+    const user = new User(api_config, access_token);
+    const user_data = await user.get();
+    user.print_summary(user_data);
+  }
 }
 
 if (!process.env.TEST_ENV) {

--- a/nodejs/scripts/get_user_boards.js
+++ b/nodejs/scripts/get_user_boards.js
@@ -38,13 +38,9 @@ async function main(argv) {
   const access_token = new AccessToken(api_config, { name: args.access_token });
   await access_token.fetch({ scopes: [Scope.READ_USERS, Scope.READ_BOARDS] });
 
-  // use the access token to get information about the user
-  const user = new User(api_config, access_token);
-  const user_data = await user.get();
-  user.print_summary(user_data);
-
   // get information about all of the boards in the user's profile
-  const board_iterator = await user.get_boards(user_data, {
+  const user = new User(api_config, access_token);
+  const board_iterator = await user.get_boards({
     query_parameters: {
       page_size: args.page_size,
       include_empty: args.include_empty,

--- a/nodejs/scripts/get_user_pins.js
+++ b/nodejs/scripts/get_user_pins.js
@@ -33,14 +33,11 @@ async function main(argv) {
       Scope.READ_USERS, Scope.READ_PINS, Scope.READ_BOARDS]
   });
 
-  // use the access token to get information about the user
-  const user = new User(api_config, access_token);
-  const user_data = await user.get();
-  user.print_summary(user_data);
-
   // get information about all of the pins in the user's profile
-  const pin_iterator = await user.get_pins(user_data,
-    { query_parameters: { page_size: args.page_size } });
+  const user = new User(api_config, access_token);
+  const pin_iterator = await user.get_pins({
+    query_parameters: { page_size: args.page_size }
+  });
   await user.print_multiple(args.page_size, 'pin', Pin, pin_iterator);
 }
 

--- a/nodejs/src/access_token.test.js
+++ b/nodejs/src/access_token.test.js
@@ -84,7 +84,7 @@ describe('v5 access_token tests', () => {
     ]);
   });
 
-  test('v5 access_token oauth', async() => {
+  test('v5 access_token oauth user token', async() => {
     const mock_api_config = jest.fn();
     mock_api_config.app_id = 'test-app-id';
     mock_api_config.app_secret = 'test-app-secret';
@@ -112,7 +112,7 @@ describe('v5 access_token tests', () => {
     const read_scopes = [Scope.READ_USERS, Scope.READ_PINS];
     await access_token.oauth({ scopes: read_scopes });
     expect(get_auth_code.mock.calls[0][0]).toBe(mock_api_config);
-    expect(get_auth_code.mock.calls[0][1]).toEqual({ scopes: read_scopes, refreshable: true });
+    expect(get_auth_code.mock.calls[0][1]).toEqual({ scopes: read_scopes });
     expect(got.post.mock.calls[0][0]).toEqual('test-api-uri/v5/oauth/token');
     expect(got.post.mock.calls[0][1]).toEqual({
       headers:
@@ -134,6 +134,53 @@ describe('v5 access_token tests', () => {
       ['<Response [42]>'],
       ['scope:', 'test-scope'],
       ['received refresh token']
+    ]);
+  });
+
+  test('v5 access_token oauth client token', async() => {
+    const mock_api_config = jest.fn();
+    mock_api_config.app_id = 'test-app-id';
+    mock_api_config.app_secret = 'test-app-secret';
+    mock_api_config.api_uri = 'test-api-uri';
+    mock_api_config.redirect_uri = 'test-redirect-uri';
+    mock_api_config.oauth_token_dir = 'test-token-dir';
+    mock_api_config.verbosity = 2;
+
+    const access_token = new AccessToken(mock_api_config, {});
+
+    got.post.mockResolvedValueOnce({
+      statusCode: 42,
+      body: {
+        status: 'test-status',
+        scope: 'test-scope',
+        access_token: 'test-access-token'
+      }
+    });
+
+    // check output
+    console.log = jest.fn();
+
+    const read_scopes = [Scope.READ_USERS, Scope.READ_PINS];
+    await access_token.oauth({ scopes: read_scopes, client_credentials: true });
+    expect(get_auth_code).not.toHaveBeenCalled();
+    expect(got.post.mock.calls[0][0]).toEqual('test-api-uri/v5/oauth/token');
+    expect(got.post.mock.calls[0][1]).toEqual({
+      headers:
+                                               {
+                                                 Authorization:
+                                                'Basic dGVzdC1hcHAtaWQ6dGVzdC1hcHAtc2VjcmV0'
+                                               },
+      form: {
+        grant_type: 'client_credentials',
+        scope: ['user_accounts:read', 'pins:read']
+      },
+      responseType: 'json'
+    });
+    expect(console.log.mock.calls).toEqual([
+      ['getting access token using client credentials...'],
+      ['POST', 'test-api-uri/v5/oauth/token'],
+      ['<Response [42]>'],
+      ['scope:', 'test-scope']
     ]);
   });
 

--- a/nodejs/src/pin.js
+++ b/nodejs/src/pin.js
@@ -56,12 +56,12 @@ export class Pin extends ApiMediaObject {
 
   // https://developers.pinterest.com/docs/api/v5/#operation/pins/create
   async create(pin_data, board_id, { section, media }) {
-    const OPTIONAL_ATTRIBUTES = [
-      'link',
-      'title',
-      'description',
-      'alt_text'
-    ];
+    const OPTIONAL_ATTRIBUTES = {
+      link: 2048,
+      title: 100,
+      description: 800,
+      alt_text: 500
+    };
     const create_data = {
       board_id: board_id
     };
@@ -88,10 +88,15 @@ export class Pin extends ApiMediaObject {
       create_data.board_section_id = section;
     }
 
-    for (const key of OPTIONAL_ATTRIBUTES) {
+    for (const [key, limit] of Object.entries(OPTIONAL_ATTRIBUTES)) {
       const value = pin_data[key];
       if (value) {
-        create_data[key] = value;
+        if (value.length > limit) {
+          console.log(`Warning: Truncating Pin ${key} to ${limit} characters.`);
+          create_data[key] = value.substring(0, limit);
+        } else {
+          create_data[key] = value;
+        }
       }
     }
 

--- a/nodejs/src/user.js
+++ b/nodejs/src/user.js
@@ -16,13 +16,13 @@ export class User extends ApiObject {
   }
 
   // https://developers.pinterest.com/docs/api/v5/#operation/boards/list
-  async get_boards(user_data, query_parameters = {}) {
+  async get_boards(query_parameters = {}) {
     // iterator that handles API paging
     return this.get_iterator('/v5/boards', query_parameters);
   }
 
   // getting all of a user's pins is not supported, so iterate through boards
-  async get_pins(user_data, query_parameters = {}) {
+  async get_pins(query_parameters = {}) {
     return this.get_iterator('/v5/pins', query_parameters);
   }
 }

--- a/nodejs/src/user.test.js
+++ b/nodejs/src/user.test.js
@@ -30,7 +30,7 @@ describe('v5 user tests', () => {
 
     const mock_get_iterator = jest.spyOn(ApiObject.prototype, 'get_iterator');
     mock_get_iterator.mockResolvedValue('test_iterator');
-    const iterator = await test_user.get_boards('test_user_data', 'query_parameters');
+    const iterator = await test_user.get_boards('query_parameters');
     expect('test_iterator').toEqual(iterator);
     expect(mock_get_iterator.mock.calls[0]).toEqual([
       '/v5/boards', 'query_parameters']);
@@ -50,7 +50,7 @@ describe('v5 user tests', () => {
 
     const expected_pins = ['board1_pin1', 'board1_pin2', 'board3_pin1'];
     let index = 0;
-    const pin_iterator = await test_user.get_pins('test_user_data', {});
+    const pin_iterator = await test_user.get_pins({});
     for await (const pin_data of pin_iterator) {
       expect(pin_data).toEqual(expected_pins[index]);
       index++;

--- a/python/scripts/copy_board.py
+++ b/python/scripts/copy_board.py
@@ -158,8 +158,7 @@ def main(argv=[]):
 
     if args.all_boards:  # copy all boards for the source user
         user = User(api_config, source_token)
-        user_data = user.get()
-        boards = user.get_boards(user_data)
+        boards = user.get_boards()
         source_board = Board(
             None, api_config, source_token
         )  # board_id set in loop below

--- a/python/scripts/delete_board.py
+++ b/python/scripts/delete_board.py
@@ -46,7 +46,7 @@ def main(argv=[]):
     if args.all_boards:  # delete all boards for the user
         user = User(api_config, access_token)
         user_data = user.get()
-        boards = user.get_boards(user_data)
+        boards = user.get_boards()
         confirmation = f"Delete all boards for {user_data['username']}"
     else:  # copy just the board designated by board_id
         deletion_board = Board(args.board_id, api_config, access_token)

--- a/python/scripts/get_user_boards.py
+++ b/python/scripts/get_user_boards.py
@@ -55,17 +55,14 @@ def main(argv=[]):
     access_token = AccessToken(api_config, name=args.access_token)
     access_token.fetch(scopes=[Scope.READ_USERS, Scope.READ_BOARDS])
 
-    # use the access token to get information about the user
-    user = User(api_config, access_token)
-    user_data = user.get()
-
     # get information about all of the boards in the user's profile
+    user = User(api_config, access_token)
     query_parameters = {"page_size": args.page_size}
     if args.include_empty:
         query_parameters["include_empty"] = args.include_empty
     if args.include_archived:
         query_parameters["include_archived"] = args.include_archived
-    board_iterator = user.get_boards(user_data, query_parameters)
+    board_iterator = user.get_boards(query_parameters)
     user.print_multiple(args.page_size, "board", Board, board_iterator)
 
 

--- a/python/scripts/get_user_pins.py
+++ b/python/scripts/get_user_pins.py
@@ -34,14 +34,9 @@ def main(argv=[]):
     access_token = AccessToken(api_config, name=args.access_token)
     access_token.fetch(scopes=[Scope.READ_USERS, Scope.READ_PINS, Scope.READ_BOARDS])
 
-    # use the access token to get information about the user
-    user = User(api_config, access_token)
-    user_data = user.get()
-
     # get information about all of the pins in the user's profile
-    pin_iterator = user.get_pins(
-        user_data, query_parameters={"page_size": args.page_size}
-    )
+    user = User(api_config, access_token)
+    pin_iterator = user.get_pins(query_parameters={"page_size": args.page_size})
     user.print_multiple(args.page_size, "pin", Pin, pin_iterator)
 
 

--- a/python/src/pin.py
+++ b/python/src/pin.py
@@ -55,12 +55,12 @@ class Pin(ApiMediaObject):
         a media identifier or the file name of a video file) to create
         a Video Pin.
         """
-        OPTIONAL_ATTRIBUTES = [
-            "link",
-            "title",
-            "description",
-            "alt_text",
-        ]
+        OPTIONAL_ATTRIBUTES = {
+            "link": 2048,
+            "title": 100,
+            "description": 800,
+            "alt_text": 500,
+        }
         create_data = {
             "board_id": board_id,
         }
@@ -82,9 +82,12 @@ class Pin(ApiMediaObject):
         if section:
             create_data["board_section_id"] = section
 
-        for key in OPTIONAL_ATTRIBUTES:
+        for key, limit in OPTIONAL_ATTRIBUTES.items():
             value = pin_data.get(key)
             if value:
+                if len(value) > limit:
+                    print(f"Warning: Truncating Pin {key} to {limit} characters.")
+                    value = value[0:limit]
                 create_data[key] = value
 
         pin_data = self.post_data("/v5/pins", create_data)

--- a/python/src/user.py
+++ b/python/src/user.py
@@ -18,10 +18,10 @@ class User(ApiObject):
         print("--------------------")
 
     # https://developers.pinterest.com/docs/api/v5/#operation/boards/list
-    def get_boards(self, user_data, query_parameters=None):
+    def get_boards(self, query_parameters=None):
         # the returned iterator handles API paging
         return self.get_iterator("/v5/boards", query_parameters)
 
     # getting all of a user's pins is not supported, so iterate through boards
-    def get_pins(self, user_data, query_parameters=None):
+    def get_pins(self, query_parameters=None):
         return self.get_iterator("/v5/pins", query_parameters)

--- a/python/tests/src/test_user.py
+++ b/python/tests/src/test_user.py
@@ -25,18 +25,17 @@ class UserTest(unittest.TestCase):
 
         mock_api_object_get_iterator.return_value = "test_iterator"
         response = test_user.get_boards(
-            "test_user_data", query_parameters={"param1": "value1", "param2": "value2"}
+            query_parameters={"param1": "value1", "param2": "value2"}
         )
         mock_api_object_get_iterator.assert_called_once_with(
             "/v5/boards", {"param1": "value1", "param2": "value2"}
         )
         self.assertEqual(response, "test_iterator")
 
-        response = test_user.get_boards("test_user_data")
+        response = test_user.get_boards()
         mock_api_object_get_iterator.assert_called_with("/v5/boards", None)
 
         response = test_user.get_boards(
-            "test_user_data",
             query_parameters={
                 "param1": "value1",
             },
@@ -61,7 +60,7 @@ class UserTest(unittest.TestCase):
         expected_pins = ["board1_pin1", "board1_pin2", "board3_pin1"]
         test_user = User(mock_api_config, "test_access_token")
         for index, pin in enumerate(
-            test_user.get_pins("test_user_data", query_parameters={"param1": "value1"})
+            test_user.get_pins(query_parameters={"param1": "value1"})
         ):
             self.assertEqual(expected_pins[index], pin)
 


### PR DESCRIPTION
* adds support for client_credentials version of OAuth
* to get github precommit actions (lint and unit tests) to work, upgrade to a new version of nodejs
* to get end-to-end (e2e) tests to work, support truncation of Pin fields
