### PR TITLE
updated getting started links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pinterest/api-quickstart
 
-Code that makes it easy to get started with the Pinterest API.
+Code that makes it easy to get started with the Pinterest API. For full details see the [getting started](https://developers.pinterest.com/docs/overview/welcome/) documentation.
 
 ## Purpose
 
@@ -12,8 +12,8 @@ This quickstart used to support Pinterest API version v3 and v4, but that code h
 
 1. Set up the environment with your credentials (app ID and secret). This configuration works with the code in all of the language-specific directories.
 
-   * Get an application ID and secret by hitting the "Connect app" button at [https://developers.pinterest.com/apps/](https://developers.pinterest.com/apps/). You may first need to follow the steps required to [request trial access](https://developers.pinterest.com/docs/getting-started/getting-access/) to the Pinterest API. You can also find step-by-step instructions on the [Glitch-based tutorial](https://pinterest-oauth-tutorial.glitch.me/).
-   * Once your app is connected, hit the Manage button for the app on [https://developers.pinterest.com/apps/](https://developers.pinterest.com/apps/) to see your App id and App secret key. (Click the Show key button to see the App secret key.)
+   * Get an application ID and secret by hitting the "Connect app" button at the [apps dashboard](https://developers.pinterest.com/apps/). You may first need to follow the steps required to [request trial access](https://developers.pinterest.com/docs/getting-started/getting-access/) to the Pinterest API. You can also find step-by-step instructions on the [Glitch-based tutorial](https://pinterest-oauth-tutorial.glitch.me/).
+   * Once your app is connected, hit the Manage button for the app on the [apps dashboard](https://developers.pinterest.com/apps/) to see your App id and App secret key. (Click the Show key button to see the App secret key.)
    * Put your App ID and App secret key in an environment script file.
      ```
      $ cd common/scripts
@@ -22,7 +22,7 @@ This quickstart used to support Pinterest API version v3 and v4, but that code h
      $ cd ../..
      ```
    * Configure the OAuth2 redirect URI required by this code.
-     1. Click on the Manage button for your application at [https://developers.pinterest.com/apps/](https://developers.pinterest.com/apps/).
+     1. Click on the Manage button for your application at the [apps dashboard](https://developers.pinterest.com/apps/).
      2. In the box labeled "Redirect link," enter `http://localhost:8085/`.
      3. Hit the return (enter) key or the Add button to save redirect URI (link).
    * Run the environment set-up script and verify the results.
@@ -53,7 +53,7 @@ This quickstart used to support Pinterest API version v3 and v4, but that code h
 
 ## OAuth 2.0 Authorization
 
-Access to Pinterest APIs via User Authorization requires following a flow based on [OAuth 2.0](https://tools.ietf.org/html/rfc6749). To learn about how to use OAuth 2.0 with the Pinterest API, check out the [Glitch-based tutorial](https://pinterest-oauth-tutorial.glitch.me/). For details regarding OAuth, please refer to our [v5 developer docs](https://developers.pinterest.com/docs/getting-started/authentication/). The code in this repo demonstrates how to initiate the flow by starting a browser, and then handling the OAuth redirect to the development machine (localhost). The browser is used to obtain an authorization code, and then the code invoked by the redirect exchanges the authorization code for an access token.
+Access to Pinterest APIs via User Authorization requires following a flow based on [OAuth 2.0](https://tools.ietf.org/html/rfc6749). To learn about how to use OAuth 2.0 with the Pinterest API, check out the [Glitch-based tutorial](https://pinterest-oauth-tutorial.glitch.me/). For details regarding OAuth, please refer to our [v5 developer docs](https://developers.pinterest.com/docs/getting-started/authentication-and-scopes/). The code in this repo demonstrates how to initiate the flow by starting a browser, and then handling the OAuth redirect to the development machine (localhost). The browser is used to obtain an authorization code, and then the code invoked by the redirect exchanges the authorization code for an access token.
 
 An access token is used to authenticate most API calls. In general, access tokens are valid for relatively long periods of time, in order to avoid asking users to go through the OAuth flow too often. When an access token expires, it is possible to refresh the token -- a capability that the code in this repo also demonstrates.
 

--- a/bash/scripts/get_access_token.sh
+++ b/bash/scripts/get_access_token.sh
@@ -27,7 +27,8 @@ echo 'getting auth_code...'
 
 # Specify the scopes for the user to authorize via OAuth.
 # This example requests typical read-only authorization.
-# For more information, see: https://developers.pinterest.com/docs/getting-started/authentication/
+# For more information, see: 
+# https://developers.pinterest.com/docs/getting-started/authentication-and-scopes/#requesting-the-right-scopes-for-your-app
 SCOPE="user_accounts:read"
 
 # This call opens the browser with the oauth information in the URI.

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -102,7 +102,7 @@ Valid OAuth 2.0 scopes for Pinterest API version v5:
   user_accounts:read  Read access to user accounts
 
 For more information, see:
-  https://developers.pinterest.com/docs/getting-started/scopes/
+  https://developers.pinterest.com/docs/getting-started/authentication-and-scopes/#pinterest-scopes
 ```
 
 ### [refresh_example.js](./scripts/refresh_example.js)

--- a/php/README.md
+++ b/php/README.md
@@ -21,7 +21,7 @@ PHP code that demonstrates the basics of how to use the Pinterest API.
    ```
    $ php -S localhost:8085
    ```
-6. [Click here](http://localhost:8085/) or point your browser at http://localhost:8085.
+6. [Click here](http://localhost:8085/) or point your browser at `http://localhost:8085`.
 
 ## Troubleshooting
 

--- a/python/README.md
+++ b/python/README.md
@@ -50,7 +50,7 @@ Here is a list of common arguments that work with all scripts:
 Below you will find a description of each script along with an example of its help documentation.
 
 ### [get_access_token.py](./scripts/get_access_token.py)
- Quick start code that demonstrates the OAuth 2.0 flow and tests the authentication by reading the user profile using the `/v5/user_account` [endpoint](https://developers.pinterest.com/docs/api/v5/#tag/user_account). Running this script with the `-w` parameter (`./scripts/get_access_token.py -w`) stores the access token in `../common/oauth_tokens/access_token.json` for future use. Use `-w` parameter in combination with the `-a` (access token name) parameter to store separate access tokens for different purposes. When requesting an access token without specifying scopes, the script will default to `user_accounts:read` `pins:read` and `boards:read`. To see a complete list of scopes, refer to the Enums in [`./src/v5/oauth_scope.py`](./src/v5/oauth_scope.py). You can also run `./scripts/get_access_token.py -s help` to see the scopes.
+ Quick start code that demonstrates the OAuth 2.0 flow and tests the authentication by reading the user profile using the `/v5/user_account` [endpoint](https://developers.pinterest.com/docs/api/v5/#tag/user_account). Running this script with the `-w` parameter (`./scripts/get_access_token.py -w`) stores the access token in `../common/oauth_tokens/access_token.json` for future use. Use `-w` parameter in combination with the `-a` (access token name) parameter to store separate access tokens for different purposes. When requesting an access token without specifying scopes, the script will default to `user_accounts:read` `pins:read` and `boards:read`. To see a complete list of scopes, refer to the Enums in [`./src/oauth_scope.py`](./src/oauth_scope.py). You can also run `./scripts/get_access_token.py -s help` to see the scopes.
 
 <!--gen-->
 ```
@@ -99,7 +99,7 @@ Valid OAuth 2.0 scopes for Pinterest API version v5:
   user_accounts:read  Read access to user accounts
 
 For more information, see:
-  https://developers.pinterest.com/docs/getting-started/scopes/
+  https://developers.pinterest.com/docs/getting-started/authentication-and-scopes/#pinterest-scopes
 ```
 
 ### [refresh_example.py](./scripts/refresh_example.py)

--- a/python/src/access_token.py
+++ b/python/src/access_token.py
@@ -152,7 +152,7 @@ class AccessToken(ApiCommon):
         """
         Execute the OAuth 2.0 process for obtaining an access token.
         For more information, see IETF RFC 6749: https://tools.ietf.org/html/rfc6749
-        and https://developers.pinterest.com/docs/getting-started/authentication/
+        and https://developers.pinterest.com/docs/getting-started/authentication-and-scopes/
         """
         if not scopes:
             scopes = [Scope.READ_USERS, Scope.READ_PINS, Scope.READ_BOARDS]

--- a/python/src/oauth_scope.py
+++ b/python/src/oauth_scope.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 
 # Enumerate the valid OAuth scopes.
-# For details, see: https://developers.pinterest.com/docs/getting-started/scopes/
+# For details, see: https://developers.pinterest.com/docs/getting-started/authentication-and-scopes/#pinterest-scopes
 class Scope(Enum):
     READ_ADS = "ads:read"
     WRITE_ADS = "ads:write"
@@ -61,5 +61,5 @@ Valid OAuth 2.0 scopes for Pinterest API version v5:
   user_accounts:read  Read access to user accounts
 
 For more information, see:
-  https://developers.pinterest.com/docs/getting-started/scopes/"""
+  https://developers.pinterest.com/docs/getting-started/authentication-and-scopes/#pinterest-scopes"""
     )

--- a/python/src/user_auth.py
+++ b/python/src/user_auth.py
@@ -108,7 +108,7 @@ def get_auth_code(api_config, scopes=None, refreshable=True):
         """
         This flow will typically be interrupted by the developer if the
         OAuth did not work in the browser. For details, see the documentation:
-         https://developers.pinterest.com/docs/getting-started/authentication/
+         https://developers.pinterest.com/docs/getting-started/authentication-and-scopes/
          https://developers.pinterest.com/docs/redoc/#section/User-Authorization/Start-the-OAuth-flow-%28explicit-server-side%29
         """  # noqa: E501 because the long URL is okay
         sys.exit("\nSorry that the OAuth redirect didn't work out. :-/")


### PR DESCRIPTION
Updated the getting-started links and a broken link, made minor edits to copy, and changed full text and redundant uri in instructions to text that fits with context \(_excluding when repo paths used_\). This was to save time, and make the documentation easier to read.

Used a bash script to make most of the edits, seeing as mostly find\/replace. The script file used was a slight variation of: 
[gist - recurse_and_replace.sh](https://gist.github.com/jhauga/4c7aa4602258ba7ef996f5f9e5ca128e)

<details>
<summary>To Expand - the items changed were: </summary>

1. FULL URI - getting-started\/authentication  
   - `https://developers.pinterest.com/docs/getting-started/authentication/`
   - to
   - `https://developers.pinterest.com/docs/getting-started/authentication-and-scopes/`
2. RENDERED LINK TEXT - `https://developers.pinterest.com/apps/`
   - `[https://developers.pinterest.com/apps/](https://developers.pinterest.com/apps/)`
   - to 
   - `the [apps dashboard](https://developers.pinterest.com/apps/)`
3. FULL URI - getting-started\/scopes
   - `https://developers.pinterest.com/docs/getting-started/scopes/`
   - to
   - `https://developers.pinterest.com/docs/getting-started/authentication-and-scopes/#pinterest-scopes`
4. REDUNDANT LINK - _inline_ http:\/\/localhost:8085
   - http:\/\/localhost:8085 _**NOTE** - rendered as link and had 1 occurence in php\/README.md_
   - to
   - `http://localhost:8085`
5. MISSING LOCAL REPO FILE - .\/src\/v5\/oauth_scope.py
   - `.\/src\/v5\/oauth_scope.py`
   - to
   - `.\/src\/oauth_scope.py`
   
</details>
