### PR TITLE
client credentials support more endpoints

### DIFF
--- a/nodejs/scripts/get_access_token.js
+++ b/nodejs/scripts/get_access_token.js
@@ -99,13 +99,10 @@ async function main(argv) {
     access_token.write();
   }
 
-  // Remove this conditional when GET /v5/user_account works with client credentials
-  if (!args.client_credentials) {
-    // use the access token to get information about the user
-    const user = new User(api_config, access_token);
-    const user_data = await user.get();
-    user.print_summary(user_data);
-  }
+  // use the access token to get information about the user
+  const user = new User(api_config, access_token);
+  const user_data = await user.get();
+  user.print_summary(user_data);
 }
 
 if (!process.env.TEST_ENV) {

--- a/python/scripts/get_access_token.py
+++ b/python/scripts/get_access_token.py
@@ -108,13 +108,11 @@ def main(argv=[]):
         print("writing access token")
         access_token.write()
 
-    # Remove this conditional when GET /v5/user_account works with client credentials
-    if not args.client_credentials:
-        # Use the access token to get information about the user. The purpose of this
-        # call is to verify that the access token is working.
-        user = User(api_config, access_token)
-        user_data = user.get()
-        user.print_summary(user_data)
+    # Use the access token to get information about the user. The purpose of this
+    # call is to verify that the access token is working.
+    user = User(api_config, access_token)
+    user_data = user.get()
+    user.print_summary(user_data)
 
 
 # If this script is being called from the command line, call the main function


### PR DESCRIPTION
Now that /v5/user_account is supported with client_credentials, there's no need for the conditionals in the get_access_token scripts.

Tested end-to-end manually.
