### PR TITLE
make end-to-end tests more stable

### DIFF
--- a/common/scripts/e2e_tests_ads
+++ b/common/scripts/e2e_tests_ads
@@ -91,3 +91,5 @@ wc "${DOCNAME}"
 # all tests existed successfully: delete output files
 rm -f ${OUTPUT_PREFIX}_*.json
 rm -f ${OUTPUT_PREFIX}_*.csv
+
+echo === ADS READ TEST COMPLETED SUCCESSFULLY ===

--- a/common/scripts/e2e_tests_read
+++ b/common/scripts/e2e_tests_read
@@ -58,3 +58,5 @@ wc ${DOCNAME}
 
 # delete output files
 rm -f ${OUTPUT_PREFIX}_*.json
+
+echo === READ TEST COMPLETED SUCCESSFULLY ===

--- a/common/scripts/e2e_tests_write
+++ b/common/scripts/e2e_tests_write
@@ -45,6 +45,10 @@ printf "Delete all boards for penelopepintridge\nyes\nyes\nyes\nyes\n" | \
 
 # Save a pin
 SAVE_BOARD_ID=$(./scripts/get_user_boards.${EXT} -a ${TEST2} --page-size 100 | grep -B 1 "${SAVE_BOARD_NAME}" | grep "Board ID" | cut -d ' ' -f 3)
+if [ "${SAVE_BOARD_ID}" == "" ] ; then
+   echo save board lookup failed, likely due to a read-after-write consistency issue with the API
+   exit 2
+fi
 ./scripts/save_pin.${EXT} -a ${TEST2} -p ${PIN} -b "${SAVE_BOARD_ID}"
 
 # The board used to test saves should have a section.
@@ -58,8 +62,24 @@ if [ -r "${VIDEO_FILE}" ] ; then
     # get the board with the pin to copy
     VIDEO_BOARD_ID=$(./scripts/get_user_boards.${EXT} -a ${TEST2} --page-size 100 | grep -B 1 "${VIDEO_BOARD_NAME}" | grep "Board ID" | cut -d ' ' -f 3)
 
+    if [ "${VIDEO_BOARD_ID}" == "" ] ; then
+       echo video board lookup failed, waiting and retrying...
+       sleep 5
+       VIDEO_BOARD_ID=$(./scripts/get_user_boards.${EXT} -a ${TEST2} --page-size 100 | grep -B 1 "${VIDEO_BOARD_NAME}" | grep "Board ID" | cut -d ' ' -f 3)
+    fi
+
+    if [ "${VIDEO_BOARD_ID}" == "" ] ; then
+       echo video board lookup failed, likely due to a read-after-write consistency issue with the API
+       exit 3
+    fi
+
     # get a single pin to copy. match 1 on second grep prevents EPIPE error in get_user_pins script.
     VIDEO_PIN_ID=$(./scripts/get_user_pins.${EXT} -a ${TEST2} --page-size 100 | grep -B 2 "${VIDEO_PIN_DESCRIPTION}" | grep -m 1 "Pin ID" | cut -d ' ' -f 3)
+
+    if [ "${VIDEO_PIN_ID}" == "" ] ; then
+       echo video pin id lookup failed, likely due to a read-after-write consistency issue with the API
+       exit 4
+    fi
 
     # copy the pin, adding the video
     ./scripts/copy_pin.${EXT} -a "${TEST2}" -p "$VIDEO_PIN_ID" -b "$VIDEO_BOARD_ID" -m "${VIDEO_FILE}"
@@ -67,3 +87,5 @@ else
     echo Skipping video pin creation test.
     echo To enable this test, put a video file here: "${VIDEO_FILE}"
 fi
+
+echo === WRITE TEST COMPLETED SUCCESSFULLY ===


### PR DESCRIPTION
It looks like the end-to-end tests might be failing due to temporary read-after-write inconsistency issues in the API. These changes flag the issues more clearly and work around one of the inconsistencies.
